### PR TITLE
Commit various enhancements

### DIFF
--- a/src/cdfio.F90
+++ b/src/cdfio.F90
@@ -409,7 +409,7 @@ CONTAINS
              iidims(1) = nid_t 
           ELSE
              PRINT *,' ERROR: ipk = ',kpk(jv), jv , sdtyvar(jv)%cname
-             STOP 99
+             STOP
           ENDIF
     
           SELECT CASE ( sdtyvar(jv)%cprecision ) ! check the precision of the variable to create
@@ -722,7 +722,7 @@ CONTAINS
     istatus = NF90_INQ_VARID(incid, cdvar, idvar)
     IF ( istatus /= NF90_NOERR ) THEN
        PRINT *, NF90_STRERROR(istatus),' in atted ( inq_varid)'
-       STOP 99
+       STOP
     ENDIF
     istatus = NF90_INQUIRE_ATTRIBUTE(incid, idvar, cdatt, xtype=ityp )
     IF ( istatus /= NF90_NOERR ) THEN
@@ -737,7 +737,7 @@ CONTAINS
          atted_char = istatus
        ELSE
          PRINT *, ' Mismatch in attribute type in atted_char'
-         STOP 99
+         STOP
        ENDIF
     ENDIF
     istatus=NF90_CLOSE(incid)
@@ -765,7 +765,7 @@ CONTAINS
     istatus = NF90_INQ_VARID(incid, cdvar, idvar)
     IF ( istatus /= NF90_NOERR ) THEN
        PRINT *, NF90_STRERROR(istatus),' in atted ( inq_varid)'
-       STOP 99
+       STOP
     ENDIF
     istatus = NF90_INQUIRE_ATTRIBUTE(incid, idvar, cdatt, xtype=ityp )
     IF ( istatus /= NF90_NOERR ) THEN
@@ -780,7 +780,7 @@ CONTAINS
          atted_r4 = istatus
        ELSE
          PRINT *, ' Mismatch in attribute type in atted_r4'
-         STOP 99
+         STOP
        ENDIF
     ENDIF
     istatus=NF90_CLOSE(incid)
@@ -830,7 +830,7 @@ CONTAINS
             ! Stop if not requesting error code for external handling
             IF ( .NOT. PRESENT(kstatus) ) THEN
               PRINT *,NF90_STRERROR(istatus)
-              PRINT *,' Exact dimension name ', TRIM(cdim_name),' not found in ',TRIM(cdfile) ; STOP 99
+              PRINT *,' Exact dimension name ', TRIM(cdim_name),' not found in ',TRIM(cdfile) ; STOP
             ELSE
               kstatus = istatus
             ENDIF
@@ -1324,31 +1324,31 @@ CONTAINS
 
              istatus=NF90_INQ_VARID (incid,'mbathy', id_var)
              IF ( istatus /=  NF90_NOERR ) THEN
-               PRINT *, 'Problem reading mesh_zgr.nc v3 : no mbathy found !' ; STOP 99
+               PRINT *, 'Problem reading mesh_zgr.nc v3 : no mbathy found !' ; STOP
              ENDIF
              istatus=NF90_GET_VAR(incid,id_var, mbathy, start=(/1,1,1/), count=(/ii,ij,1/) )
              !
              istatus=NF90_INQ_VARID (incid,'e3t_ps', id_var)
              IF ( istatus /=  NF90_NOERR ) THEN
-               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3t_ps found !' ; STOP 99
+               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3t_ps found !' ; STOP
              ENDIF
              istatus=NF90_GET_VAR(incid,id_var,e3t_ps, start=(/1,1,1/), count=(/ii,ij,1/) )
              !
              istatus=NF90_INQ_VARID (incid,'e3w_ps', id_var)
              IF ( istatus /=  NF90_NOERR ) THEN
-               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3w_ps found !' ; STOP 99
+               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3w_ps found !' ; STOP
              ENDIF
              istatus=NF90_GET_VAR(incid,id_var,e3w_ps, start=(/1,1,1/), count=(/ii,ij,1/) )
              !
              istatus=NF90_INQ_VARID (incid,'e3t_0', id_var)
              IF ( istatus /=  NF90_NOERR ) THEN
-               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3t_0 found !' ; STOP 99
+               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3t_0 found !' ; STOP
              ENDIF
              istatus=NF90_GET_VAR(incid,id_var,e3t_0, start=(/1,1/), count=(/ik0,1/) )
              !
              istatus=NF90_INQ_VARID (incid,'e3w_0', id_var)
              IF ( istatus /=  NF90_NOERR ) THEN
-               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3w_0 found !' ; STOP 99
+               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3w_0 found !' ; STOP
              ENDIF
              istatus=NF90_GET_VAR(incid,id_var,e3w_0, start=(/1,1/), count=(/ik0,1/) )
              DO ji=1,ii
@@ -1569,7 +1569,7 @@ CONTAINS
     IF ( istatus /= 0 ) THEN
        PRINT *,' Problem in getvar for ', TRIM(clvar)
        CALL ERR_HDL(istatus)
-       STOP 99
+       STOP
     ENDIF
 
     ! Caution : order does matter !
@@ -1674,7 +1674,7 @@ CONTAINS
     IF ( istatus /= 0 ) THEN
        PRINT *,' Problem in getvar3d for ', TRIM(cdvar)
        CALL ERR_HDL(istatus)
-       STOP 99
+       STOP
     ENDIF
 
     ! Caution : order does matter !
@@ -1779,7 +1779,7 @@ CONTAINS
     IF ( istatus /= 0 ) THEN
        PRINT *,' Problem in getvar3dt for ', TRIM(cdvar)
        CALL ERR_HDL(istatus)
-       STOP 99
+       STOP
     ENDIF
 
     ! Caution : order does matter !
@@ -1889,7 +1889,7 @@ CONTAINS
     IF ( istatus /= 0 ) THEN
        PRINT *,' Problem in getvar4d for ', TRIM(cdvar)
        CALL ERR_HDL(istatus)
-       STOP 99
+       STOP
     ENDIF
 
     ! Caution : order does matter !
@@ -1994,7 +1994,7 @@ CONTAINS
     IF ( istatus /= 0 ) THEN
        PRINT *,' Problem in getvarxz for ', TRIM(cdvar)
        CALL ERR_HDL(istatus)
-       STOP 99
+       STOP
     ENDIF
 
     ! Caution : order does matter !
@@ -2100,7 +2100,7 @@ CONTAINS
     IF ( istatus /= 0 ) THEN
        PRINT *,' Problem in getvaryz for ', TRIM(cdvar)
        CALL ERR_HDL(istatus)
-       STOP 99
+       STOP
     ENDIF
 
     ! Caution : order does matter !
@@ -2282,7 +2282,7 @@ CONTAINS
        PRINT *,' Problem in getvare3 for ', TRIM(cdvar)
        PRINT *,TRIM(cdfile), kk
        CALL ERR_HDL(istatus)
-       STOP 99
+       STOP
     ENDIF
 
     istatus=NF90_CLOSE(incid)
@@ -2395,7 +2395,7 @@ CONTAINS
              END DO
              IF (jj == jpdep +1 ) THEN
                 PRINT *,' No depth variable found in ', TRIM(cdfile)
-                STOP 99
+                STOP
              ENDIF
           ENDIF
        ENDIF
@@ -2780,7 +2780,7 @@ CONTAINS
        iid = nid_timb
     CASE DEFAULT
        PRINT *, 'E R R O R: CASE ',cdtype,' do not coded'
-       STOP 99
+       STOP
     END SELECT
 
     istart(:) = 1
@@ -2969,7 +2969,7 @@ CONTAINS
     IF (kstatus /=  NF90_NOERR ) THEN
        PRINT *, 'ERROR in NETCDF routine, status=',kstatus
        PRINT *,NF90_STRERROR(kstatus)
-       STOP 99
+       STOP
     END IF
 
   END SUBROUTINE ERR_HDL
@@ -3045,7 +3045,7 @@ CONTAINS
     ELSE 
        PRINT *,'  ERROR : variable ',TRIM(cdvar),' has ', indim, &
             &       ' dimensions !. Only 3 or 4 supported'
-       STOP 99
+       STOP
     ENDIF
 
     ! convert to physical values
@@ -3233,7 +3233,7 @@ CONTAINS
           IF ( GetNcFile%idimids(jvar,4) /= GetNcFile%iunlim ) THEN
              PRINT *, ' 4D variables must have an unlimited time dimension ...'
              PRINT *, ' Cannot process this file :', TRIM(cd_file)
-             STOP 99
+             STOP
           ENDIF
           idt = GetNcFile%idimids(jvar,4) 
        ENDIF
@@ -3247,7 +3247,7 @@ CONTAINS
 
     IF ( idx == -1 .OR. idy == -1 ) THEN 
        PRINT *, ' ERROR : no x, y dimensions found'
-       STOP 99
+       STOP
     ENDIF
 
     ! get dimensions

--- a/src/cdfio.F90
+++ b/src/cdfio.F90
@@ -1089,7 +1089,7 @@ CONTAINS
     IF (  PRESENT (cdep) ) cldep = cdep
 
     ! Note the very important TRIM below : if not, getdim crashes as it never find the correct dim !
-    iipk = getdim(cdfile, TRIM(cldep), kstatus=istatus, ldexact=.false.)
+    iipk = getdim(cdfile, TRIM(cldep), kstatus=istatus)
 
     IF ( istatus /= 0 ) THEN
        PRINT *,' getipk : vertical dim not found ...assume 1'

--- a/src/cdfmean.f90
+++ b/src/cdfmean.f90
@@ -440,15 +440,15 @@ PROGRAM cdfmean
 
            IF (dvol2d /= 0 )THEN
               dvmeanout(jk) = dsum2d/dvol2d
-              WRITE(6,*)' Mean value', cpbas, ' at level ',ik,'(',gdep(jk),' m) ',dvmeanout(jk), 'surface = ',dsurf/1.e6,' km^2'
+              WRITE(6,*)' Mean value', TRIM(cpbas), ' at level ',ik,'(',gdep(jk),' m) ',dvmeanout(jk), 'surface = ',dsurf/1.e6,' km^2'
               WRITE(numout,9004) gdep(jk), ik, dvmeanout(jk)
               IF ( lvar ) THEN
                 dvariance(jk) = dvar2d/dvol2d - dvmeanout(jk) * dvmeanout(jk)
-                WRITE(6,*)' Variance value', cpbas, ' at level ',ik,'(',gdep(jk),' m) ',dvariance(jk), 'surface = ',dsurf/1.e6,' km^2'
+                WRITE(6,*)' Variance value', TRIM(cpbas), ' at level ',ik,'(',gdep(jk),' m) ',dvariance(jk), 'surface = ',dsurf/1.e6,' km^2'
                 WRITE(numvar,9004) gdep(jk), ik, dvariance(jk)
               ENDIF
            ELSE
-              WRITE(6,*) ' No points in the water', cpbas, ' at level ',ik,'(',gdep(jk),' m) '
+              WRITE(6,*) ' No points in the water', TRIM(cpbas), ' at level ',ik,'(',gdep(jk),' m) '
               dvmeanout(jk) = 99999.
               IF( lvar ) dvariance(jk) = 99999.
            ENDIF
@@ -469,13 +469,13 @@ PROGRAM cdfmean
         IF ( lbas ) cpbas = ' for basin '//cbasins(jbasin)
 
         dvmeanout3d(jbasin,jt) = dsum(jbasin) / dvol(jbasin)
-        WRITE(6,*) ' Mean value over the ocean', cpbas, ': ', dvmeanout3d(jbasin,jt), jt
+        WRITE(6,*) ' Mean value over the ocean', TRIM(cpbas), ': ', dvmeanout3d(jbasin,jt), jt
         rdummy(:,:) = dvmeanout3d(jbasin,jt)
         ierr = putvar0d(ncout, id_varout(zb + 2), rdummy, ktime=jt )
 
         IF ( lvar ) THEN
           dvariance3d(jbasin,jt) = dvar(jbasin) / dvol(jbasin) - dsum(jbasin) / dvol(jbasin) * dsum(jbasin) / dvol(jbasin)
-          WRITE(6,*) ' Variance over the ocean', cpbas, ': ', dvariance3d(jbasin,jt), jt
+          WRITE(6,*) ' Variance over the ocean', TRIM(cpbas), ': ', dvariance3d(jbasin,jt), jt
           rdummy(:,:) = dvariance3d(jbasin,jt)
           ierr = putvar0d(ncout, id_varout(zb + 4), rdummy, ktime=jt )
         ENDIF

--- a/src/cdfmean.f90
+++ b/src/cdfmean.f90
@@ -143,7 +143,7 @@ PROGRAM cdfmean
      PRINT *,'       - ASCII files : ', TRIM(cf_out) 
      PRINT *,'                       [ ',TRIM(cf_var),', in case of -var ]'
      PRINT *,'       - all output on ASCII files are also sent to standard output.'
-     STOP 99
+     STOP
   ENDIF
 
   ! Open standard output with recl=256 to avoid wrapping of long lines (ifort)
@@ -165,7 +165,7 @@ PROGRAM cdfmean
      CASE ('-out_pref')
         IF ( ijarg > narg ) THEN
             PRINT *, '  ERROR: provide an argument to -out_pref'
-            STOP 99
+            STOP
         ENDIF
         CALL getarg (ijarg, cf_outpref) ; ijarg = ijarg + 1 
         cf_out   = TRIM(cf_outpref)//TRIM(cf_out)
@@ -176,12 +176,12 @@ PROGRAM cdfmean
         lbas = .NOT. chkfile (cn_fbasins)
         IF ( .NOT. lbas ) THEN
             PRINT *, '  ERROR: -basins is used but "'//TRIM(cn_fbasins)//'" does not exist'
-            STOP 99
+            STOP
         ENDIF
 
         IF ( ijarg > narg ) THEN
             PRINT *, '  ERROR: provide arguments to -basins'
-            STOP 99
+            STOP
         ENDIF
         CALL getarg (ijarg, cldum) ; ijarg = ijarg + 1
         READ(cldum,*) nbasin
@@ -190,7 +190,7 @@ PROGRAM cdfmean
         DO jbasin = 1, nbasin
            IF ( ijarg > narg ) THEN
                PRINT *, '  ERROR: n_basins must match the number of basin names provided'
-               STOP 99
+               STOP
            ENDIF
            CALL getarg (ijarg, cbasins(jbasin)) ; ijarg = ijarg + 1
         END DO
@@ -208,7 +208,7 @@ PROGRAM cdfmean
         CASE ( 9 ) ; READ(cldum,*) ikmax
         CASE DEFAULT 
           PRINT *, '  ERROR : Too many arguments ...'
-          STOP 99
+          STOP
         END SELECT
      END SELECT
   END DO
@@ -217,7 +217,7 @@ PROGRAM cdfmean
   lchk = chkfile(cn_fzgr) .OR. lchk
   lchk = chkfile(cn_fmsk) .OR. lchk
   lchk = chkfile(cf_in  ) .OR. lchk
-  IF ( lchk ) STOP 99 ! missing file
+  IF ( lchk ) STOP ! missing file
 
   cv_dep   = 'none'
   npiglo = getdim (cf_in, cn_x)
@@ -308,7 +308,7 @@ PROGRAM cdfmean
      cv_dep   = cn_gdepw
   CASE DEFAULT
      PRINT *, 'this type of variable is not known :', TRIM(ctype)
-     STOP 99
+     STOP
   END SELECT
 
   e1(:,:) = getvar  (cn_fhgr, cv_e1,  1,  npiglo, npjglo, kimin=iimin, kjmin=ijmin)

--- a/src/cdfmoc.f90
+++ b/src/cdfmoc.f90
@@ -172,7 +172,7 @@ PROGRAM cdfmoc
      PRINT *,'       traditionally.'
      PRINT *,'       Additional variables are also computed following CLIVAR-GODAE '
      PRINT *,'       reanalysis intercomparison project recommendations. '
-     STOP 99
+     STOP
   ENDIF
 
   cglobal = 'Partial step computation'
@@ -198,7 +198,7 @@ PROGRAM cdfmoc
         CASE ( 4 ) ; cf_ufil = cldum
         CASE DEFAULT
            PRINT*, 'ERROR : Too many arguments ...'
-           STOP 99
+           STOP
         END SELECT
      END SELECT
   END DO
@@ -208,12 +208,12 @@ PROGRAM cdfmoc
   lchk = lchk .OR. chkfile ( cn_fmsk )
   lchk = lchk .OR. chkfile ( cf_vfil )
   IF ( ldec ) lchk = lchk .OR. chkfile ( TRIM(cf_tfil) ) 
-  IF ( lchk ) STOP 99  ! missing file(s)
+  IF ( lchk ) STOP  ! missing file(s)
 
   IF ( lrap ) THEN 
      ! all the work will be done in a separated routine for RAPID-MOCHA section
      CALL rapid_amoc 
-     STOP 99  ! program stops here in this case
+     STOP  ! program stops here in this case
   ENDIF
 
   npiglo = getdim (cf_vfil,cn_x)

--- a/src/cdfmoc.f90
+++ b/src/cdfmoc.f90
@@ -71,7 +71,7 @@ PROGRAM cdfmoc
   REAL(KIND=4), DIMENSION(:),     ALLOCATABLE :: gdepw           ! depthw
   REAL(KIND=4), DIMENSION(:),     ALLOCATABLE :: gdept           ! deptht
   REAL(KIND=4), DIMENSION(:),     ALLOCATABLE :: e31d            ! e3 1D : used if full step
-  REAL(KIND=4), DIMENSION(:),     ALLOCATABLE :: tim             ! time counter array
+  REAL(KIND=8), DIMENSION(:),     ALLOCATABLE :: tim             ! time counter array
 
   REAL(KIND=8), DIMENSION(:,:,:), ALLOCATABLE :: dmoc            ! nbasins x npjglo x npk
 
@@ -296,9 +296,9 @@ PROGRAM cdfmoc
   ! 1 : global ; 2 : Atlantic ; 3 : Indo-Pacif ; 4 : Indian ; 5 : Pacif
   ibmask(npglo,:,:) = getvar(cn_fmsk,   'vmask', 1, npiglo, npjglo)
   IF ( lbas ) THEN
-     ibmask(npatl,:,:) = getvar(cn_fbasins, 'tmaskatl', 1, npiglo, npjglo)
-     ibmask(npind,:,:) = getvar(cn_fbasins, 'tmaskind', 1, npiglo, npjglo)
-     ibmask(nppac,:,:) = getvar(cn_fbasins, 'tmaskpac', 1, npiglo, npjglo)
+     ibmask(npatl,:,:) = getvar(cn_fbasins, cn_vatlmsk, 1, npiglo, npjglo)
+     ibmask(npind,:,:) = getvar(cn_fbasins, cn_vindmsk, 1, npiglo, npjglo)
+     ibmask(nppac,:,:) = getvar(cn_fbasins, cn_vpacmsk, 1, npiglo, npjglo)
      ibmask(npinp,:,:) = ibmask(nppac,:,:) + ibmask(npind,:,:)  ! indo pacific mask
      ! ensure that there are no overlapping on the masks
      WHERE(ibmask(npinp,:,:) > 0 ) ibmask(npinp,:,:) = 1
@@ -1150,9 +1150,9 @@ PROGRAM cdfmoc
 
        END DO   ! time loop
 
-       tim  = getvar1d( cf_vfil, cn_vtimec, npt     )
-       ierr = putvar1d( ncout,   tim,       npt, 'T')
-       ierr = closeout( ncout                       )
+       tim  = getvar1d8( cf_vfil, cn_vtimec, npt     )
+       ierr = putvar1d(  ncout,   tim,       npt, 'T')
+       ierr = closeout(  ncout                       )
 
      END SUBROUTINE rapid_amoc
 
@@ -1333,7 +1333,7 @@ PROGRAM cdfmoc
   ncout = create      ( cf_moc,  'none',    1, npjglo, npk, cdep=cn_vdepthw )
   ierr  = createvar   ( ncout,   stypvar,   nvarout,   ipk, id_varout, cdglobal=TRIM(cglobal)           )
   ierr  = putheadervar( ncout,   cf_vfil,   1, npjglo, npk, pnavlon=rdumlon, pnavlat=rdumlat, pdep=gdepw)
-  tim   = getvar1d    ( cf_vfil, cn_vtimec, npt                    )
+  tim   = getvar1d8   ( cf_vfil, cn_vtimec, npt                    )
   ierr  = putvar1d    ( ncout,   tim,       npt, 'T')
 
      END SUBROUTINE CreateOutput

--- a/src/cdfmoc.f90
+++ b/src/cdfmoc.f90
@@ -172,7 +172,7 @@ PROGRAM cdfmoc
      PRINT *,'       traditionally.'
      PRINT *,'       Additional variables are also computed following CLIVAR-GODAE '
      PRINT *,'       reanalysis intercomparison project recommendations. '
-     STOP
+     STOP 99
   ENDIF
 
   cglobal = 'Partial step computation'
@@ -198,7 +198,7 @@ PROGRAM cdfmoc
         CASE ( 4 ) ; cf_ufil = cldum
         CASE DEFAULT
            PRINT*, 'ERROR : Too many arguments ...'
-           STOP
+           STOP 99
         END SELECT
      END SELECT
   END DO
@@ -208,12 +208,12 @@ PROGRAM cdfmoc
   lchk = lchk .OR. chkfile ( cn_fmsk )
   lchk = lchk .OR. chkfile ( cf_vfil )
   IF ( ldec ) lchk = lchk .OR. chkfile ( TRIM(cf_tfil) ) 
-  IF ( lchk ) STOP  ! missing file(s)
+  IF ( lchk ) STOP 99  ! missing file(s)
 
   IF ( lrap ) THEN 
      ! all the work will be done in a separated routine for RAPID-MOCHA section
      CALL rapid_amoc 
-     STOP  ! program stops here in this case
+     STOP 99  ! program stops here in this case
   ENDIF
 
   npiglo = getdim (cf_vfil,cn_x)

--- a/src/cdftools.f90
+++ b/src/cdftools.f90
@@ -89,7 +89,7 @@ CONTAINS
 
     IF ( .NOT. ALLOCATED (dl_glam) ) THEN 
 
-    IF (chkfile (clcoo) ) STOP ! missing file
+    IF (chkfile (clcoo) ) STOP 99 ! missing file
 
     ipiglo= getdim (clcoo, cn_x)
     ipjglo= getdim (clcoo, cn_y)

--- a/src/cdftools.f90
+++ b/src/cdftools.f90
@@ -89,7 +89,7 @@ CONTAINS
 
     IF ( .NOT. ALLOCATED (dl_glam) ) THEN 
 
-    IF (chkfile (clcoo) ) STOP 99 ! missing file
+    IF (chkfile (clcoo) ) STOP ! missing file
 
     ipiglo= getdim (clcoo, cn_x)
     ipjglo= getdim (clcoo, cn_y)

--- a/src/modcdfnames.f90
+++ b/src/modcdfnames.f90
@@ -190,8 +190,8 @@ MODULE modCdfNames
     NAMELIST/namvars/ cn_sohefldo, cn_solhflup, cn_sosbhfup
     NAMELIST/namvars/ cn_solwfldo, cn_soshfldo
     NAMELIST/namvars/ cn_sowaflup, cn_sowaflcd, cn_sowafldp, cn_iowaflup
-    NAMELIST/namvars/ cn_zomsfatl, cn_zomsfglo, cn_zomsfpac, cn_zomsfinp, cn_zomsfind
-    NAMELIST/namvars/ cn_zoisoatl, cn_zoisoglo, cn_zoisopac, cn_zoisoinp, cn_zoisoind
+    NAMELIST/namvars/ cn_zomsfatl, cn_zomsfglo, cn_zomsfpac, cn_zomsfinp, cn_zomsfind, cn_zomsfinp0
+    NAMELIST/namvars/ cn_zoisoatl, cn_zoisoglo, cn_zoisopac, cn_zoisoinp, cn_zoisoind, cn_zoisoinp0
     NAMELIST/namvars/ cn_vozout, cn_vomevt, cn_vozous, cn_vomevs
     NAMELIST/namvars/ cn_sozout, cn_somevt, cn_sozous, cn_somevs
     NAMELIST/namvars/ cn_sozoutrp, cn_somevtrp
@@ -276,6 +276,7 @@ CONTAINS
     READ(inam, namvars    )
     READ(inam, nambathy   )
     READ(inam, namsqdvar  )
+    READ(inam, namcubvar  )
     READ(inam, nammeshmask     )
     READ(inam, nammeshmask_var )
     CLOSE ( inam ) 


### PR DESCRIPTION
I've been making a few changes to the cdftools as required for an update to ocean validation software. In summary, these are:

#### Enhancements
* Write time coordinate variables as double precision
  * Several supporting functions have been added in `cdfio`
  * This has **only been applied to `cdfmean` and `cdfmoc`** at the moment
* Added basin mask support and output file specification to `cdfmean`
  * New syntax: `cdfmean ... -out_suff output_file_suffix -basins n_basins basin_names`

#### Bug fixes
* Fix bug with `getvar` in `cdfio` when called for mesh mask files
  * The `getvar` function calls `getdim(...,cn_x)`, which does not work when accessing mesh mask variables
  * Since mesh mask dimension names are still hard-coded, I have added a get_dim(..., 'x') if the above fails
* Fix `cn_v...msk` namelist variables not being referenced in `cdfmoc`
* Add missing namelists and namelist variables in `modcdfnames`

Would these have value to the cdftools community? 

cc @TimGraham1982 for interest