### PR TITLE
Cdftools exit status

### DIFF
--- a/src/cdf16bit.f90
+++ b/src/cdf16bit.f90
@@ -80,12 +80,12 @@ PROGRAM cdf16bit
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : same names than in input file'
-     STOP
+     STOP 99
   ENDIF
   !!
   ijarg = 1
   CALL getarg (ijarg, cf_in) ; ijarg = ijarg + 1
-  IF ( chkfile(cf_in)  ) STOP ! missing file
+  IF ( chkfile(cf_in)  ) STOP 99 ! missing file
 
   ! Check for options and reflect options on logical flags
   DO WHILE ( ijarg <= narg)  
@@ -97,7 +97,7 @@ PROGRAM cdf16bit
      CASE ( '-verbose' )          ! information will be given level by level
         l_chk=.true. ; l_verbose=.true.
      CASE DEFAULT
-        PRINT *,' OPTION ',TRIM(cldum),' not supported.' ; STOP
+        PRINT *,' OPTION ',TRIM(cldum),' not supported.' ; STOP 99
      END SELECT
   END DO
 
@@ -108,7 +108,10 @@ PROGRAM cdf16bit
 
   IF (ierr /= 0 ) THEN
      npk   = getdim (cf_in,'z',kstatus=ierr)
-     IF (ierr /= 0 ) STOP 'depth dimension name not suported'
+     IF (ierr /= 0 ) THEN
+        PRINT *, 'depth dimension name not suported'
+        STOP 99
+     ENDIF
   ENDIF
   npt    = getdim (cf_in, cn_t)
 

--- a/src/cdf2levitusgrid2d.f90
+++ b/src/cdf2levitusgrid2d.f90
@@ -108,7 +108,7 @@ PROGRAM cdf2levitusgrid2d
       PRINT *,'     OUTPUT : '
       PRINT *,'       netcdf file : name given as second argument'
       PRINT *,'         variables : 2d_var_name'
-      STOP
+      STOP 99
    ENDIF
 
    ijarg = 1
@@ -120,7 +120,7 @@ PROGRAM cdf2levitusgrid2d
    lchk = chkfile (cn_fmsk)         .OR. lchk
    lchk = chkfile (cf_levitus_mask) .OR. lchk
    lchk = chkfile (cf_in)           .OR. lchk
-   IF ( lchk ) STOP ! missing files
+   IF ( lchk ) STOP 99 ! missing files
 
    npiglo = getdim(cf_in,cn_x)
    npjglo = getdim(cf_in,cn_y)
@@ -431,7 +431,7 @@ PROGRAM cdf2levitusgrid2d
 
          CASE DEFAULT 
             PRINT *, ' METHOD ', imethod ,'is not recognized in this program'
-            STOP
+            STOP 99
 
          END SELECT  ! imethod
          IF ( ALLOCATED(z_fill) ) DEALLOCATE( z_fill )

--- a/src/cdf2levitusgrid3d.f90
+++ b/src/cdf2levitusgrid3d.f90
@@ -114,7 +114,7 @@ PROGRAM cdf2levitusgrid3d
       PRINT *,'     OUTPUT : '
       PRINT *,'       netcdf file : name given as second argument'
       PRINT *,'         variables : 3d_var_name'
-      STOP
+      STOP 99
    ENDIF
 
    ijarg = 1
@@ -140,7 +140,7 @@ PROGRAM cdf2levitusgrid3d
    lchk = chkfile (cn_fhgr)
    lchk = chkfile (cn_fmsk)         .OR. lchk
    lchk = chkfile (cf_in)           .OR. lchk
-   IF ( lchk ) STOP ! missing files
+   IF ( lchk ) STOP 99 ! missing files
 
    npiglo = getdim(cf_in,cn_x)
    npjglo = getdim(cf_in,cn_y)
@@ -464,7 +464,7 @@ PROGRAM cdf2levitusgrid3d
 
          CASE DEFAULT 
             PRINT *, ' METHOD ', imethod ,'is not recognized in this program'
-            STOP
+            STOP 99
 
          END SELECT  ! imethod
          IF ( ALLOCATED(z_fill) ) DEALLOCATE( z_fill )

--- a/src/cdf2matlab.f90
+++ b/src/cdf2matlab.f90
@@ -63,7 +63,7 @@ PROGRAM cdf2matlab
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : same name than in input file.'
-     STOP
+     STOP 99
   ENDIF
   !!
   !! Initialisation from 1st file (all file are assume to have the same geometry)
@@ -71,7 +71,7 @@ PROGRAM cdf2matlab
   CALL getarg (2, cv_in)
   CALL getarg (3, cldum) ; READ(cldum,*) ilev
 
-  IF ( chkfile (cf_in) ) STOP  ! missing file
+  IF ( chkfile (cf_in) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_in,cn_x)
   npjglo = getdim (cf_in,cn_y)

--- a/src/cdf_xtrac_brokenline.f90
+++ b/src/cdf_xtrac_brokenline.f90
@@ -182,7 +182,7 @@ PROGRAM cdf_xtract_brokenline
       PRINT *,'     SEE ALSO :'
       PRINT *,'        cdftransport, cdfmoc, cdfmocsig. This tool replaces cdfovide.' 
       PRINT *,'      '
-      STOP
+      STOP 99
    ENDIF
 
    ! Decode command line
@@ -218,7 +218,7 @@ PROGRAM cdf_xtract_brokenline
          lchk = chkfile(cf_sec(jsec) ) .OR. lchk
       ENDDO
    ENDIF
-   IF ( lchk     ) STOP ! missing files
+   IF ( lchk     ) STOP 99 ! missing files
 
    ! nvar and nsec are  now fixed
    ALLOCATE( stypvar(nvar), ipk(nvar), id_varout(nvar) )

--- a/src/cdfbathy.f90
+++ b/src/cdfbathy.f90
@@ -129,7 +129,7 @@ PROGRAM cdfbathy
      PRINT 9999, '             a sequence number is added at the end of the input file name, to keep'
      PRINT 9999, '             modifications.'
      PRINT *,'            variables : same as input file'
-     STOP
+     STOP 99
   ENDIF
 9999 FORMAT(5x,a)
 
@@ -213,11 +213,11 @@ PROGRAM cdfbathy
      !
      CASE DEFAULT
         PRINT *, cldum,' : unknown option '
-        STOP
+        STOP 99
      END SELECT
   END DO
   
-  IF ( lchk ) STOP  ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   IF ( lmodif .AND. .NOT. loverwrite) THEN
      ! creating a working copy of the file indexed by iversion

--- a/src/cdfbci.f90
+++ b/src/cdfbci.f90
@@ -69,11 +69,11 @@ PROGRAM cdfbci
      PRINT *,'      '
      PRINT *,'     SEE ALSO :'
      PRINT *,'       cdfmoyuvwt '
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg(1, cf_in)
-  IF (chkfile(cf_in) .OR. chkfile (cn_fhgr) ) STOP
+  IF (chkfile(cf_in) .OR. chkfile (cn_fhgr) ) STOP 99
 
   npiglo = getdim(cf_in, cn_x)
   npjglo = getdim(cf_in, cn_y)
@@ -118,7 +118,7 @@ PROGRAM cdfbci
   !test if lev exists
   IF ((npk==0) .AND. (ilev > 0) ) THEN
      PRINT *, 'Problem : npk = 0 and lev > 0 STOP'
-     STOP
+     STOP 99
   END IF
 
   ! create output fileset

--- a/src/cdfbn2.f90
+++ b/src/cdfbn2.f90
@@ -76,7 +76,7 @@ PROGRAM cdfbn2
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : ', TRIM(cv_bn2)
-     STOP
+     STOP 99
   ENDIF
 
   cglobal = 'Partial step computation'
@@ -89,13 +89,13 @@ PROGRAM cdfbn2
      SELECT CASE (cldum)
      CASE ('W','w') ; l_w   = .true.
      CASE ('-full') ; lfull = .true. ; cglobal = 'full step computation'
-     CASE DEFAULT   ; PRINT *,' Option not understood :', TRIM(cldum) ; STOP
+     CASE DEFAULT   ; PRINT *,' Option not understood :', TRIM(cldum) ; STOP 99
      END SELECT
   END DO
 
   lchk = chkfile (cn_fzgr )
   lchk = lchk .OR. chkfile (cf_tfil  )
-  IF ( lchk  ) STOP  ! missing files 
+  IF ( lchk  ) STOP 99 ! missing files 
 
   npiglo = getdim (cf_tfil, cn_x)
   npjglo = getdim (cf_tfil, cn_y)

--- a/src/cdfbotpressure.f90
+++ b/src/cdfbotpressure.f90
@@ -92,7 +92,7 @@ PROGRAM cdfbotpressure
       PRINT *,'     SEE ALSO :'
       PRINT *,'        cdfvint'
       PRINT *,'      '
-      STOP
+      STOP 99
    ENDIF
 
    ! browse command line
@@ -108,7 +108,7 @@ PROGRAM cdfbotpressure
          ij = ij + 1
          SELECT CASE ( ij)
          CASE ( 1 ) ; cf_in = cldum
-         CASE DEFAULT ; PRINT *, ' ERROR: Too many arguments ! ' ; STOP
+         CASE DEFAULT ; PRINT *, ' ERROR: Too many arguments ! ' ; STOP 99
          END SELECT
       END SELECT
    END DO
@@ -119,7 +119,7 @@ PROGRAM cdfbotpressure
    lchk = chkfile ( cf_in   )
    lchk = chkfile ( cn_fmsk ) .OR. lchk
    lchk = chkfile ( cn_fzgr ) .OR. lchk
-   IF ( lchk ) STOP ! missing files
+   IF ( lchk ) STOP 99 ! missing files
 
    ! log information so far
    cf_out = 'botpressure.nc'

--- a/src/cdfbottom.f90
+++ b/src/cdfbottom.f90
@@ -72,13 +72,13 @@ PROGRAM cdfbottom
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables :  same names than input file, long_name attribute is'
      PRINT *,'               prefixed by Bottom '
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1
   CALL getarg (ijarg, cf_in) ; ijarg = ijarg + 1
 
-  IF ( chkfile(cf_in) ) STOP  ! missing files
+  IF ( chkfile(cf_in) ) STOP 99 ! missing files
 
   npiglo = getdim (cf_in,cn_x)
   npjglo = getdim (cf_in,cn_y)
@@ -105,7 +105,7 @@ PROGRAM cdfbottom
 
   DO WHILE ( ijarg <= narg )
      CALL getarg (ijarg, ctype ) ; ijarg = ijarg + 1
-     IF ( chkfile (cn_fmsk ) ) STOP  ! missing mask file
+     IF ( chkfile (cn_fmsk ) ) STOP 99 ! missing mask file
 
      SELECT CASE ( ctype )
      CASE ( 'T', 't', 'S', 's' )
@@ -119,7 +119,7 @@ PROGRAM cdfbottom
         PRINT *, 'Be carefull with fmask ... !!!'
      CASE DEFAULT
         PRINT *, ' ERROR : This type of point ', ctype,' is not known !'
-        STOP
+        STOP 99
      END SELECT
 
   END DO

--- a/src/cdfbottomsig.f90
+++ b/src/cdfbottomsig.f90
@@ -81,13 +81,13 @@ PROGRAM cdfbottomsig
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : sobotsig0 or sobotsigi ( kg/m3 - 1000 )' 
      PRINT *,'                     or sobotsigntr (kg/m3)'
-     STOP
+     STOP 99
   ENDIF
 
   cv_sig = 'sobotsig0'
   cref=''
   CALL getarg (1, cf_tfil)
-  IF ( chkfile(cf_tfil) ) STOP ! missing file
+  IF ( chkfile(cf_tfil) ) STOP 99 ! missing file
 
   IF ( narg == 2 ) THEN
      CALL getarg (2, cldum) 

--- a/src/cdfbti.f90
+++ b/src/cdfbti.f90
@@ -83,14 +83,14 @@ PROGRAM cdfbti
      PRINT *,'     SEE ALSO :'
      PRINT *,'      cdfmoyuvwt, cdfbci, cdfnrjcomp, cdfkempemekeepe'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg(1, cf_uvwtfil)
 
   lchk = chkfile (cn_fhgr )
   lchk = lchk .OR. chkfile (cf_uvwtfil )
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   npiglo  = getdim(cf_uvwtfil,cn_x)
   npjglo  = getdim(cf_uvwtfil,cn_y)

--- a/src/cdfbuoyflx.f90
+++ b/src/cdfbuoyflx.f90
@@ -132,7 +132,7 @@ PROGRAM cdfbuoyflx
      PRINT *,'     SEE ALSO :'
      PRINT *,'      '
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
   ijarg   = 1
   cf_flxfil='none'
@@ -164,10 +164,10 @@ PROGRAM cdfbuoyflx
         lsho = .true. ; np_varout = 1
      CASE DEFAULT
         PRINT *, " Option ", TRIM(cldum)," not supported "
-        STOP
+        STOP 99
      END SELECT
   ENDDO
-  IF (lchk ) STOP ! missing files
+  IF (lchk ) STOP 99 ! missing files
 
   IF ( cf_flxfil == 'none' ) THEN
     cf_flxfil = cf_tfil

--- a/src/cdfcensus.f90
+++ b/src/cdfcensus.f90
@@ -131,7 +131,7 @@ PROGRAM cdfcensus
      PRINT *,'                       sigma2  (kg/m3 -1000 )'
      PRINT *,'                       sigma3  (kg/m3 -1000 )'
      PRINT *,'       - bimg file   : According to options.'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1
@@ -142,7 +142,7 @@ PROGRAM cdfcensus
   lchk =           chkfile ( cn_fzgr )
   lchk = lchk .OR. chkfile ( cn_fhgr )
   lchk = lchk .OR. chkfile ( cf_tfil  )
-  IF ( lchk ) STOP  ! some compulsory files are missing
+  IF ( lchk ) STOP 99 ! some compulsory files are missing
 
   PRINT *,' TS_FILE = ',TRIM(cf_tfil)
   PRINT *,' NLOG    = ', nlog
@@ -199,7 +199,7 @@ PROGRAM cdfcensus
         lfull = .TRUE.
      CASE DEFAULT
         PRINT *,' Unknown option :',TRIM(cldum)
-        STOP
+        STOP 99
      END SELECT
   END DO
 

--- a/src/cdfchgrid.f90
+++ b/src/cdfchgrid.f90
@@ -97,7 +97,7 @@ PROGRAM cdfchgrid
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out)
      PRINT *,'         variable : same name as in input file'
-     STOP
+     STOP 99
   ENDIF
   !!
   ijarg = 1
@@ -119,11 +119,11 @@ PROGRAM cdfchgrid
         ldbg = .TRUE.
      CASE DEFAULT
         PRINT *, TRIM(cldum),' : unknown option '
-        STOP
+        STOP 99
      END SELECT
   END DO
 
-  IF ( chkfile(cf_in) .OR. chkfile(cf_ref) ) STOP  ! missing files
+  IF ( chkfile(cf_in) .OR. chkfile(cf_ref) ) STOP 99 ! missing files
 
   ! get domain dimension from input file
   npiglo = getdim (cf_in, cn_x)

--- a/src/cdfclip.f90
+++ b/src/cdfclip.f90
@@ -87,7 +87,7 @@ PROGRAM cdfclip
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out),' This can be changed using -o option'
      PRINT *,'         variables : same as input variables.'
-     STOP
+     STOP 99
   ENDIF
   !!
   ijarg=1 
@@ -108,11 +108,11 @@ PROGRAM cdfclip
     CASE ('-o')
        CALL getarg(ijarg,cldum) ; ijarg = ijarg + 1 ; cf_out=cldum
     CASE DEFAULT
-       PRINT *,' Unknown option :', TRIM(cldum) ; STOP
+       PRINT *,' Unknown option :', TRIM(cldum) ; STOP 99
     END SELECT
   ENDDO
 
-  IF ( chkfile (cf_in ) ) STOP ! missing file
+  IF ( chkfile (cf_in ) ) STOP 99 ! missing file
 
   ! set global attribute for output file
   IF ( ikmin > 0 ) THEN
@@ -145,7 +145,7 @@ PROGRAM cdfclip
       IF (ierr /= 0 ) THEN
          PRINT *,' assume file with no depth'
          IF ( ikmin > 0 ) THEN
-           PRINT *,' You cannot specify limits on k level !' ; STOP
+           PRINT *,' You cannot specify limits on k level !' ; STOP 99
          ENDIF
          npk=0  ! means no dim level in file (implicitly 1 level)
       ENDIF
@@ -179,7 +179,7 @@ PROGRAM cdfclip
   IF (npkk > npk ) THEN
    PRINT *,' It seems that you want levels that are not represented '
    PRINT *,' in any of the variables that are in the file ',TRIM(cf_in)
-   STOP
+   STOP 99
   ENDIF
 
   ALLOCATE( v2d(npiglo,npjglo),rlon(npiglo,npjglo), rlat(npiglo,npjglo), rdepg(npk) , rdep(npkk))

--- a/src/cdfcmp.f90
+++ b/src/cdfcmp.f90
@@ -66,7 +66,7 @@ PROGRAM cdfcmp
      PRINT *,'      '
      PRINT *,'     OUTPUT : '
      PRINT *,'       output is done on standard output.'
-     STOP
+     STOP 99
   ENDIF
   !!
   ijarg  = 1
@@ -90,12 +90,12 @@ PROGRAM cdfcmp
         CALL getarg(ijarg, cldum) ; ijarg = ijarg + 1 ; READ(cldum,*) ijmax
      CASE DEFAULT
         PRINT *, TRIM(cldum),' : unknown option '
-        STOP
+        STOP 99
      END SELECT
   END DO
 
-  IF ( chkfile(cf1_in) .OR. chkfile(cf2_in) ) STOP ! missing file
-  IF ( chkvar(cf1_in, cv_in) .OR. chkvar(cf2_in, cv_in) ) STOP  ! missing var
+  IF ( chkfile(cf1_in) .OR. chkfile(cf2_in) ) STOP 99 ! missing file
+  IF ( chkvar(cf1_in, cv_in) .OR. chkvar(cf2_in, cv_in) ) STOP 99 ! missing var
 
   npiglo = getdim (cf1_in, cn_x)
   npjglo = getdim (cf1_in, cn_y)

--- a/src/cdfcoastline.f90
+++ b/src/cdfcoastline.f90
@@ -43,7 +43,7 @@ PROGRAM cdfcofpoint
      PRINT *,'    if jmin = 0 then ALL j are taken'
      PRINT *,'    if kmin = 0 then ALL k are taken'
      PRINT *,'    output file is pointcoast.nc    '
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cfile)
@@ -58,7 +58,7 @@ PROGRAM cdfcofpoint
   IF (narg > 3 ) THEN
     IF ( narg /= 5 ) THEN
        PRINT *, ' ERROR : You must give 6 optional values (imin imax jmin jmax kmin kmax)'
-       STOP
+       STOP 99
     ELSE
     ! input optional imin imax jmin jmax
       CALL getarg ( 2,cldum) ; READ(cldum,*) imin

--- a/src/cdfcofdis.f90
+++ b/src/cdfcofdis.f90
@@ -86,7 +86,7 @@ PROGRAM cdfcofdis
      PRINT *,'         variables : ', TRIM(cv_out),' (m)'
      PRINT *,'      '
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
  
   CALL getarg(1,cn_fhgr)  ! overwrite standard name eventually
@@ -96,7 +96,7 @@ PROGRAM cdfcofdis
   lchk =           chkfile ( cn_fhgr )
   lchk = lchk .OR. chkfile ( cn_fmsk )
   lchk = lchk .OR. chkfile ( cf_tfil )
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   iarg = 4 
   DO WHILE ( iarg <= narg )
@@ -108,7 +108,7 @@ PROGRAM cdfcofdis
        lsurf = .true.
     CASE DEFAULT
        PRINT *,' unknown option : ', TRIM(cldum)
-       STOP
+       STOP 99
     END SELECT
   END DO
 
@@ -121,7 +121,7 @@ PROGRAM cdfcofdis
     jpk = getdim(cf_tfil,'z')
     IF ( jpk == 0 ) THEN
       PRINT *,' ERROR in determining jpk form gridT file ....'
-      STOP
+      STOP 99
     ENDIF
   ENDIF
 

--- a/src/cdfcoloc.f90
+++ b/src/cdfcoloc.f90
@@ -116,7 +116,7 @@ PROGRAM cdfcoloc
      PRINT *,'     Return a column ascii file id dep fields()'
      PRINT *,  TRIM(cn_fmsk),' is required in local directory'
      PRINT *,  TRIM(cn_fcoo),',',TRIM(cn_fzgr),' are also required for slope computation'
-     STOP
+     STOP 99
   ENDIF
 
   iarg = 1
@@ -132,7 +132,7 @@ PROGRAM cdfcoloc
      CASE ('-b'   ) ; CALL getarg ( iarg, cf_bathy       ) ; iarg = iarg + 1
      CASE ('-l'   ) ; CALL getarg ( iarg, ctmplst0       ) ; iarg = iarg + 1
      CASE ('-h'   ) ; CALL help_message 
-     CASE DEFAULT   ; PRINT *,TRIM(cldum),' : option not available.' ; STOP
+     CASE DEFAULT   ; PRINT *,TRIM(cldum),' : option not available.' ; STOP 99
      END SELECT
   ENDDO
 
@@ -154,13 +154,13 @@ PROGRAM cdfcoloc
 
   IF ( cf_bathy /= 'none' ) THEN ! dealing with special case of etopo file
     llchk = llchk .OR. chkfile(cf_bathy    )
-    IF (llchk ) STOP ! missing files
+    IF (llchk ) STOP 99 ! missing files
     npiglo = getdim (cf_bathy,'lon')
     npjglo = getdim (cf_bathy,'lat')
     npk    = 1
   ELSE
     llchk = llchk .OR. chkfile(cn_fmsk    )
-    IF (llchk ) STOP ! missing files
+    IF (llchk ) STOP 99 ! missing files
     npiglo = getdim (cn_fmsk,cn_x)
     npjglo = getdim (cn_fmsk,cn_y)
     npk    = getdim (cn_fmsk,cn_z)
@@ -304,7 +304,7 @@ PROGRAM cdfcoloc
         dscale    = 1.d0
      END SELECT
 
-     IF (chkfile (cf_weight) .OR. chkfile( cf_in) )  STOP ! missing file
+     IF (chkfile (cf_weight) .OR. chkfile( cf_in) )  STOP 99 ! missing file
 
      ! Now enter the generic processing
      PRINT *,'START coloc for ', TRIM(cctyp)
@@ -541,7 +541,7 @@ CONTAINS
        ENDDO
        IF ( jt == jptyp + 1 ) THEN
           PRINT *, 'ERROR in field list :', TRIM(cltype(jtyp) ),' not supported'
-          STOP
+          STOP 99
        ENDIF
     ENDDO
     
@@ -558,12 +558,12 @@ CONTAINS
     IF ( nSx * nSy < 0 ) THEN 
        PRINT *, ' You must specify both Sx and Sy'
        PRINT *, ' in order to perform rotation'
-       STOP
+       STOP 99
     ENDIF
     IF ( nU  * nV  < 0 ) THEN 
        PRINT *, ' You must specify both U and V'
        PRINT *, ' in order to perform rotation'
-       STOP
+       STOP 99
     ENDIF
 
     ! build output file name
@@ -631,7 +631,7 @@ CONTAINS
     DO jtyp=1, jptyp
       PRINT '( 12a,x,24a,x,10a)', TRIM(ctype(jtyp)), comments(jtyp), crequired(jtyp)
     ENDDO
-    STOP
+    STOP 99
 
   END SUBROUTINE help_message
 

--- a/src/cdfconvert.f90
+++ b/src/cdfconvert.f90
@@ -99,7 +99,7 @@ PROGRAM cdfconvert
      PRINT *,'     SEE ALSO :'
      PRINT *,'       cdfflxconv, cdfsstconv, cdfstrconv'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
   !!
   CALL getarg (1, ctag)
@@ -114,7 +114,7 @@ PROGRAM cdfconvert
   cf_dimgt   = TRIM(confcase)//'_T_'  //TRIM(ctag)//'.dimg' ; lchk = lchk .OR. chkfile(cf_dimgt )
   cf_dimgs   = TRIM(confcase)//'_S_'  //TRIM(ctag)//'.dimg' ; lchk = lchk .OR. chkfile(cf_dimgs )
   cf_dimg2d  = TRIM(confcase)//'_2D_' //TRIM(ctag)//'.dimg' ; lchk = lchk .OR. chkfile(cf_dimg2d)
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   cf_dimgssh = TRIM(confcase)//'_SSH_'//TRIM(ctag)//'.dimg'
   cf_dimguu  = TRIM(confcase)//'_UU_' //TRIM(ctag)//'.dimg'

--- a/src/cdfcsp.f90
+++ b/src/cdfcsp.f90
@@ -58,12 +58,12 @@ PROGRAM cdfcsp
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : same as input file (modified)'
      PRINT *,'         variables : same as input file'
-     STOP
+     STOP 99
   ENDIF
 
   !! Initialisation from 1st file (all file are assume to have the same geometry)
   CALL getarg (1, cf_in)
-  IF ( chkfile (cf_in) ) STOP ! missing file
+  IF ( chkfile (cf_in) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_in, cn_x)
   npjglo = getdim (cf_in, cn_y)
@@ -95,7 +95,7 @@ PROGRAM cdfcsp
 
   DO jf = 1, narg
      CALL getarg (jf, cf_in)
-     IF ( chkfile (cf_in) ) STOP ! missing file
+     IF ( chkfile (cf_in) ) STOP 99 ! missing file
      PRINT *, 'Change spval on file ', cf_in
      ncid = ncopen(cf_in)
      npt  = getdim (cf_in,cn_t)

--- a/src/cdfcurl.f90
+++ b/src/cdfcurl.f90
@@ -97,7 +97,7 @@ PROGRAM cdfcurl
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : socurl or socurlt (if -T option), units : s^-1'
      PRINT *,'            or socurloverf, no units (if -overf option)'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg=1
@@ -133,7 +133,7 @@ PROGRAM cdfcurl
   lchk = chkfile(cn_fhgr ) .OR. lchk
   lchk = chkfile(cf_ufil ) .OR. lchk
   lchk = chkfile(cf_vfil ) .OR. lchk
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
 
   ! define new variables for output
@@ -174,7 +174,7 @@ PROGRAM cdfcurl
   IF ( (npk==0) .AND. (nlev > 0) .AND. .NOT. lsurf ) THEN
      PRINT *, 'Problem : npk = 0 and lev > 0 STOP'
      PRINT *, '  Use -surf option is dealing with single level file on C grid '
-     STOP
+     STOP 99
   END IF
 
   ! case of 1 level on C-grid

--- a/src/cdfdegradt.f90
+++ b/src/cdfdegradt.f90
@@ -105,7 +105,7 @@ PROGRAM cdfdegradt
      PRINT *,'       netcdf file : degraded_cdfvar.nc '
      PRINT *,'       netcdf file : flsdc.nc'
      PRINT *,'      '
-    STOP
+    STOP 99
   ENDIF
 
   cglobal = 'Partial step computation'
@@ -127,7 +127,7 @@ PROGRAM cdfdegradt
         CASE ( 6 ) ; READ(cldum,*) ijmin
         CASE DEFAULT
           PRINT *, ' ERROR : Too many arguments ...'
-          STOP
+          STOP 99
         END SELECT
      END SELECT
   END DO
@@ -136,7 +136,7 @@ PROGRAM cdfdegradt
   lchk = chkfile(cn_fzgr) .OR. lchk
   lchk = chkfile(cn_fmsk) .OR. lchk
   lchk = chkfile(cf_tfil) .OR. lchk
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   cv_dep = 'none'
   npiglo = getdim (cf_tfil, cn_x)
@@ -163,11 +163,11 @@ PROGRAM cdfdegradt
   IF (npk   == 0 ) THEN ; npk = 1;  ENDIF ! no depth dimension ==> 1 level
   IF (iimin < 2 )  THEN
      PRINT *,'iimin value is too low'
-     STOP
+     STOP 99
   END IF
   IF (ijmin  < 2 ) THEN
      PRINT *,'ijmin value is too low'
-     STOP
+     STOP 99
   END IF
   npiglo = ( (npiglo - iimin ) / nri )*nri
   npjglo = ( (npjglo - ijmin ) / nrj )*nrj

--- a/src/cdfdegradu.f90
+++ b/src/cdfdegradu.f90
@@ -104,7 +104,7 @@ PROGRAM cdfdegradu
      PRINT *,'       netcdf file : degraded_cdfvar.nc '
      PRINT *,'       netcdf file : flsdc.nc'
      PRINT *,'      '
-    STOP
+    STOP 99
   ENDIF
 
   cglobal = 'Partial step computation'
@@ -126,7 +126,7 @@ PROGRAM cdfdegradu
         CASE ( 6 ) ; READ(cldum,*) ijmin
         CASE DEFAULT
           PRINT *, ' ERROR : Too many arguments ...'
-          STOP
+          STOP 99
         END SELECT
      END SELECT
   END DO
@@ -135,7 +135,7 @@ PROGRAM cdfdegradu
   lchk = chkfile(cn_fzgr) .OR. lchk
   lchk = chkfile(cn_fmsk) .OR. lchk
   lchk = chkfile(cf_ufil) .OR. lchk
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   cv_dep = 'none'
   npiglo = getdim (cf_ufil, cn_x)
@@ -162,11 +162,11 @@ PROGRAM cdfdegradu
   IF (npk   == 0 ) THEN ; npk = 1;  ENDIF ! no depth dimension ==> 1 level
   IF (iimin < 1 )  THEN
      PRINT *,'iimin value is too low'
-     STOP
+     STOP 99
   END IF
   IF (ijmin  < 2 ) THEN
      PRINT *,'ijmin value is too low'
-     STOP
+     STOP 99
   END IF
   npiglo = ( (npiglo - iimin - 1 ) / nri )*nri + 1
   npjglo = ( (npjglo - ijmin ) / nrj )*nrj

--- a/src/cdfdegradv.f90
+++ b/src/cdfdegradv.f90
@@ -104,7 +104,7 @@ PROGRAM cdfdegradv
      PRINT *,'       netcdf file : degraded_cdfvar.nc '
      PRINT *,'       netcdf file : flsdc.nc'
      PRINT *,'      '
-    STOP
+    STOP 99
   ENDIF
 
   cglobal = 'Partial step computation'
@@ -126,7 +126,7 @@ PROGRAM cdfdegradv
         CASE ( 6 ) ; READ(cldum,*) ijmin
         CASE DEFAULT
           PRINT *, ' ERROR : Too many arguments ...'
-          STOP
+          STOP 99
         END SELECT
      END SELECT
   END DO
@@ -135,7 +135,7 @@ PROGRAM cdfdegradv
   lchk = chkfile(cn_fzgr) .OR. lchk
   lchk = chkfile(cn_fmsk) .OR. lchk
   lchk = chkfile(cf_vfil) .OR. lchk
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   cv_dep = 'none'
   npiglo = getdim (cf_vfil, cn_x)
@@ -162,11 +162,11 @@ PROGRAM cdfdegradv
   IF (npk   == 0 ) THEN ; npk = 1;  ENDIF ! no depth dimension ==> 1 level
   IF (iimin < 2 )  THEN
      PRINT *,'iimin value is too low'
-     STOP
+     STOP 99
   END IF
   IF (ijmin  < 1 ) THEN
      PRINT *,'ijmin value is too low'
-     STOP
+     STOP 99
   END IF
   npiglo = ( (npiglo - iimin ) / nri )*nri
   npjglo = ( (npjglo - ijmin - 1 ) / nrj )*nrj + 1

--- a/src/cdfdegradw.f90
+++ b/src/cdfdegradw.f90
@@ -104,7 +104,7 @@ PROGRAM cdfdegradw
      PRINT *,'       netcdf file : degraded_cdfvar.nc '
      PRINT *,'       netcdf file : flsdc.nc'
      PRINT *,'      '
-    STOP
+    STOP 99
   ENDIF
 
   cglobal = 'Partial step computation'
@@ -126,7 +126,7 @@ PROGRAM cdfdegradw
         CASE ( 6 ) ; READ(cldum,*) ijmin
         CASE DEFAULT
           PRINT *, ' ERROR : Too many arguments ...'
-          STOP
+          STOP 99
         END SELECT
      END SELECT
   END DO
@@ -135,7 +135,7 @@ PROGRAM cdfdegradw
   lchk = chkfile(cn_fzgr) .OR. lchk
   lchk = chkfile(cn_fmsk) .OR. lchk
   lchk = chkfile(cf_wfil) .OR. lchk
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   cv_dep = 'none'
   npiglo = getdim (cf_wfil, cn_x)
@@ -162,11 +162,11 @@ PROGRAM cdfdegradw
   IF (npk   == 0 ) THEN ; npk = 1;  ENDIF ! no depth dimension ==> 1 level
   IF (iimin < 2 )  THEN
      PRINT *,'iimin value is too low'
-     STOP
+     STOP 99
   END IF
   IF (ijmin  < 2 ) THEN
      PRINT *,'ijmin value is too low'
-     STOP
+     STOP 99
   END IF
   npiglo = ( (npiglo - iimin ) / nri )*nri
   npjglo = ( (npjglo - ijmin ) / nrj )*nrj

--- a/src/cdfdifmask.f90
+++ b/src/cdfdifmask.f90
@@ -54,14 +54,14 @@ PROGRAM cdfdifmask
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'       variables : tmask, umask, vmask, fmask'
-     STOP
+     STOP 99
   ENDIF
   CALL getarg (1, cf_msk1)
   CALL getarg (2, cf_msk2)
 
   lchk =           chkfile ( cf_msk1 )
   lchk = lchk .OR. chkfile ( cf_msk2 )
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   npiglo = getdim (cf_msk1, cn_x)
   npjglo = getdim (cf_msk1, cn_y)

--- a/src/cdfdiv.f90
+++ b/src/cdfdiv.f90
@@ -94,7 +94,7 @@ PROGRAM cdfdiv
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : div units : s^-1'
      PRINT *,'               or divoverf, no units (if -overf option)'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg=1
@@ -129,7 +129,7 @@ PROGRAM cdfdiv
   lchk = chkfile(cn_fzgr ) .OR. lchk
   lchk = chkfile(cf_ufil ) .OR. lchk
   lchk = chkfile(cf_vfil ) .OR. lchk
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   ! define new variables for output
   stypvar(1)%cname             = 'div'
@@ -166,7 +166,7 @@ PROGRAM cdfdiv
   IF ( (npk==0) .AND. (nlev > 0) .AND. .NOT. lsurf ) THEN
      PRINT *, 'Problem : npk = 0 and lev > 0 STOP'
      PRINT *, '  Use -surf option is dealing with single level file on C grid '
-     STOP
+     STOP 99
   END IF
 
   ! case of 1 level on C-grid

--- a/src/cdfeddyscale.f90
+++ b/src/cdfeddyscale.f90
@@ -89,13 +89,13 @@ PROGRAM cdfeddyscale
      PRINT *,'      '
      PRINT *,'     SEE ALSO :'
      PRINT *,'       cdfeddyscale_pass1 '
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg(1, cf_meanfil)
 
   lchk = chkfile(cf_meanfil ) .OR. lchk
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   npiglo = getdim(cf_meanfil,cn_x)
   npjglo = getdim(cf_meanfil,cn_y)

--- a/src/cdfeddyscale_pass1.f90
+++ b/src/cdfeddyscale_pass1.f90
@@ -104,7 +104,7 @@ PROGRAM cdfeddyscale_pass1
       PRINT *,'      '
       PRINT *,'     SEE ALSO : '
       PRINT *,'        cdfeddyscale'
-      STOP
+      STOP 99
    ENDIF
 
 
@@ -117,7 +117,7 @@ PROGRAM cdfeddyscale_pass1
    lchk = chkfile(cn_fhgr ) .OR. lchk
    lchk = chkfile(cf_ufil ) .OR. lchk
    lchk = chkfile(cf_vfil ) .OR. lchk
-   IF ( lchk ) STOP ! missing files
+   IF ( lchk ) STOP 99 ! missing files
 
    ! load the dimension
    npiglo = getdim(cf_ufil,cn_x)
@@ -134,7 +134,7 @@ PROGRAM cdfeddyscale_pass1
    !test if lev exists
    IF ( (npk==0) .AND. (ilev > 1) ) THEN
       PRINT *, 'Problem : npk = 0 and lev > 0 STOP'
-      STOP
+      STOP 99
    ELSE
       npk = 1
    END IF

--- a/src/cdfeke.f90
+++ b/src/cdfeke.f90
@@ -91,7 +91,7 @@ PROGRAM cdfeke
      PRINT *,'       netcdf file : ', TRIM(cf_out) , ' unless -o option in use.'
      PRINT *,'         variables : voeke (m2/s)'
      PRINT *,'         variables : vomke (m2/s) if required'
-     STOP
+     STOP 99
   ENDIF
   !!
   !! Initialisation from 1st file (all file are assume to have the same geometry)
@@ -124,7 +124,7 @@ PROGRAM cdfeke
   IF ( nfree /= 3 .AND. nfree /= 5 ) THEN
     PRINT *, ' +++ ERROR : not the correct number of free arguments'
     PRINT *, '            Likely a wrong option or missing file name'
-    STOP
+    STOP 99
   ENDIF
 
   ! ( 2 )
@@ -162,7 +162,7 @@ PROGRAM cdfeke
     lchk = lchk .OR. chkfile (cf_v2fil)
   ENDIF
 
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   npiglo = getdim (cf_ufil,cn_x)
   npjglo = getdim (cf_ufil,cn_y)

--- a/src/cdfenstat.f90
+++ b/src/cdfenstat.f90
@@ -110,7 +110,7 @@ PROGRAM cdfenstat
      PRINT *,'       netcdf file : ', TRIM(cf_out), 'unless -o option in use'
      PRINT *,'       variables : are the same than in the input files. Standard Dev are '
      PRINT *,'        named  stdev_<variable>'
-     STOP
+     STOP 99
   ENDIF
 
   ALLOCATE ( cf_list(narg) )
@@ -136,7 +136,7 @@ PROGRAM cdfenstat
   ! Initialisation from  1rst file (all file are assume to have the same geometry)
   ! time counter can be different for each file in the list. It is read in the
   ! loop for files
-  IF ( chkfile (cf_list(1)) ) STOP ! missing file
+  IF ( chkfile (cf_list(1)) ) STOP 99 ! missing file
 
   cf_in  = cf_list(1)
   npiglo = getdim (cf_in,cn_x)
@@ -164,14 +164,14 @@ PROGRAM cdfenstat
   ! check that all files have the same number of time frames
   ierr = 0
   DO jfil = 1, nfil
-     IF (  chkfile (cf_list(jfil)      ) ) STOP ! missing file
+     IF (  chkfile (cf_list(jfil)      ) ) STOP 99 ! missing file
      inpt = getdim (cf_list(jfil), cn_t)
      IF ( inpt /= npt ) THEN
         PRINT *, 'File ',TRIM(cf_list(jfil) ),' has ',inpt,' time frames instead of ', npt
         ierr = ierr + 1
      ENDIF
   ENDDO
-  IF ( ierr /= 0 ) STOP ! frame numbers mismatch
+  IF ( ierr /= 0 ) STOP 99 ! frame numbers mismatch
 
   PRINT *, 'npiglo = ', npiglo
   PRINT *, 'npjglo = ', npjglo

--- a/src/cdfets.f90
+++ b/src/cdfets.f90
@@ -92,12 +92,12 @@ PROGRAM cdfets
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : voets (days)  and sorosrad (m)'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_tfil)
   lchk = ( chkfile (cf_tfil) .OR. chkfile( cn_fhgr ) .OR. chkfile( cn_fzgr) )
-  IF ( lchk )  STOP ! missing file
+  IF ( lchk )  STOP 99 ! missing file
 
   npiglo = getdim (cf_tfil,cn_x)
   npjglo = getdim (cf_tfil,cn_y)

--- a/src/cdffindij.f90
+++ b/src/cdffindij.f90
@@ -97,7 +97,7 @@ PROGRAM cdffindij
      PRINT *,'      '
      PRINT *,'     OUTPUT : '
      PRINT *,'       Output is done on standard output.'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1 ; ireq = 0
@@ -119,7 +119,7 @@ PROGRAM cdffindij
        CASE ( 3 ) ; READ(cldum,*) ymin
        CASE ( 4 ) ; READ(cldum,*) ymax
        CASE DEFAULT 
-         PRINT *,' Too many arguments !' ; STOP
+         PRINT *,' Too many arguments !' ; STOP 99
        END SELECT
     END SELECT
   END DO

--- a/src/cdffixtime.f90
+++ b/src/cdffixtime.f90
@@ -102,7 +102,7 @@ PROGRAM cdffixtime
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : Input file is modified (only attributes)'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   ! browse line option
@@ -130,11 +130,11 @@ PROGRAM cdffixtime
         lkeep=.true.
      CASE DEFAULT 
          PRINT *,' Option ',TRIM(cldum),' unknown'
-         STOP
+         STOP 99
      END SELECT
   END DO
   
-  IF ( chkfile(cf_in) ) STOP ! missing file
+  IF ( chkfile(cf_in) ) STOP 99 ! missing file
   PRINT *,' Changing time on file :', TRIM(cf_in)
 
   ! if ctag = none, try to find it from the file name.

--- a/src/cdfflxconv.f90
+++ b/src/cdfflxconv.f90
@@ -82,7 +82,7 @@ PROGRAM cdfflxconv
      PRINT *,'    Output 6 cdf files : for emp, qnet, qsr, sst, taux, tauy with standard var name :'
      PRINT *,'        sowaflup, sohefldo, soshfldo, sst, sozotaux, sometauy '
      PRINT *,'    coordinates.diags ( clipper like) is required in current dir '
-     STOP
+     STOP 99
   ENDIF
   !!
   CALL getarg (1, cdum)
@@ -416,7 +416,7 @@ PROGRAM cdfflxconv
         READ(numsstp,REC=ntp-1) (( v2d(ji,jj,itt),ji=1,npiglo),jj=1,npjglo)
         itime(itt)=julday(INT(timetagp(ntp-2)) )
      ELSE
-        PRINT *,' Something is wrong in previous file SST ' ; STOP
+        PRINT *,' Something is wrong in previous file SST ' ; STOP 99
      ENDIF
   ENDIF
   DO jt=1,nt
@@ -460,7 +460,7 @@ PROGRAM cdfflxconv
            READ(numsstn,REC=4) (( v2d(ji,jj,itt),ji=1,npiglo),jj=1,npjglo)
            itime(itt)=julday(INT(timetagn(3)) )
         ELSE
-           PRINT *,' Something is wrong in next file SST ' ; STOP
+           PRINT *,' Something is wrong in next file SST ' ; STOP 99
         ENDIF
      ENDIF
   ENDIF

--- a/src/cdffracinv.f90
+++ b/src/cdffracinv.f90
@@ -62,19 +62,19 @@ PROGRAM cdffracinv
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : ', TRIM(cv_out)
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1 
   CALL getarg (ijarg, cf_trc) ; ijarg = ijarg + 1
 
-  IF ( chkfile(cf_trc) ) STOP ! missing file
+  IF ( chkfile(cf_trc) ) STOP 99 ! missing file
 
   DO WHILE (ijarg <= narg )
      CALL getarg(ijarg,cldum  ) ; ijarg = ijarg + 1
      SELECT CASE ( cldum )
      CASE ( '-inv' ) ; CALL getarg(ijarg, cv_inv) ; ijarg =ijarg + 1
-     CASE DEFAULT ; PRINT *, 'option ', TRIM(cldum),' not understood' ; STOP
+     CASE DEFAULT ; PRINT *, 'option ', TRIM(cldum),' not understood' ; STOP 99
      END SELECT
   END DO
 

--- a/src/cdffwc.f90
+++ b/src/cdffwc.f90
@@ -104,7 +104,7 @@ PROGRAM cdffwc
       PRINT *,'         variables :  fwc_BASIN, where BASIN was set by argument BASIN-var*'
       PRINT *,'                      (cAsE sensitive !)'
       PRINT *,'      '
-      STOP
+      STOP 99
    ENDIF
 
 
@@ -123,7 +123,7 @@ PROGRAM cdffwc
          SELECT CASE ( ij)
          CASE ( 1 ) ; cf_in = cldum
          CASE ( 2 ) ; CALL ParseVars(cldum)
-         CASE DEFAULT ; PRINT *, ' ERROR: Too many arguments ! ' ; STOP
+         CASE DEFAULT ; PRINT *, ' ERROR: Too many arguments ! ' ; STOP 99
          END SELECT
       END SELECT
    END DO
@@ -134,7 +134,7 @@ PROGRAM cdffwc
    lchk = chkfile ( cn_fhgr ) .OR. lchk
    lchk = chkfile ( cn_fzgr ) .OR. lchk
    lchk = chkfile (cf_subbas) .OR. lchk
-   IF ( lchk ) STOP ! missing files
+   IF ( lchk ) STOP 99 ! missing files
 
    sclf      = 1.
 
@@ -165,7 +165,7 @@ PROGRAM cdffwc
 
   ! just chck if var exist in file 
   DO jvar = 1, nvaro
-     IF ( chkvar( cf_subbas, cv_in(jvar)) ) STOP  ! message is written in cdfio.chkvar
+     IF ( chkvar( cf_subbas, cv_in(jvar)) ) STOP 99 ! message is written in cdfio.chkvar
   ENDDO
 
    

--- a/src/cdfgeo-uv.f90
+++ b/src/cdfgeo-uv.f90
@@ -104,7 +104,7 @@ PROGRAM cdfgeo_uv
      PRINT *,'           variables : ', TRIM(cn_vomecrty)
      PRINT *,'           Unless -C option is used : '
      PRINT *,'             *** CAUTION:  this variable is located on U-point ***'
-     STOP
+     STOP 99
   ENDIF
 
   cl_global=' (Ugeo, Vgeo ) are on ( V, U ) points of the C-grid'
@@ -128,7 +128,7 @@ PROGRAM cdfgeo_uv
          cl_global=' (Ugeo, Vgeo ) are on ( U, V ) points of the C-grid (velocity interp)'
        ELSE
          PRINT *, ' +++ ERROR: -C can use only option 1 or 2 +++'
-         STOP
+         STOP 99
        ENDIF
     CASE DEFAULT
        PRINT *, '  +++ ERROR: Argument ',TRIM(cl_dum),' not supported. +++'
@@ -138,7 +138,7 @@ PROGRAM cdfgeo_uv
   lchk = chkfile(cn_fhgr)
   lchk = chkfile(cn_fzgr) .OR. lchk
   lchk = chkfile(cf_tfil) .OR. lchk
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   npiglo = getdim(cf_tfil, cn_x)
   npjglo = getdim(cf_tfil, cn_y)

--- a/src/cdfgeostrophy.f90
+++ b/src/cdfgeostrophy.f90
@@ -153,7 +153,7 @@ PROGRAM cdfgeostrophy
      PRINT *,'           variables : ', TRIM(cn_vozocrtx)
      PRINT *,'       - netcdf file : ', TRIM(cf_vout) 
      PRINT *,'           variables : ', TRIM(cn_vomecrty)
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg(1, cf_tfil)
@@ -162,7 +162,7 @@ PROGRAM cdfgeostrophy
   lchk = chkfile(cn_fzgr) .OR. lchk
   lchk = chkfile(cn_fmsk) .OR. lchk
   lchk = chkfile(cf_tfil) .OR. lchk
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   npiglo = getdim(cf_tfil, cn_x)
   npjglo = getdim(cf_tfil, cn_y)

--- a/src/cdfgradT.f90
+++ b/src/cdfgradT.f90
@@ -82,7 +82,7 @@ PROGRAM cdfgradT
       PRINT *,'     SEE ALSO :'
       PRINT *,'      '
       PRINT *,'      '
-      STOP
+      STOP 99
    ENDIF
 
    CALL getarg (1, cf_tfil)
@@ -97,7 +97,7 @@ PROGRAM cdfgradT
    lchk = ( lchk .OR. chkfile(cn_fhgr) )
    lchk = ( lchk .OR. chkfile(cn_fzgr) )
    lchk = ( lchk .OR. chkfile(cn_fmsk) )
-   IF (lchk ) STOP ! missing file
+   IF (lchk ) STOP 99 ! missing file
 
    npiglo = getdim (cf_tfil, cn_x)
    npjglo = getdim (cf_tfil, cn_y)

--- a/src/cdfhdy.f90
+++ b/src/cdfhdy.f90
@@ -74,14 +74,14 @@ PROGRAM cdfhdy
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : sohdy (m)'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_tfil )
   CALL getarg (2, cldum   ) ;        READ(cldum,*) nlev1
   CALL getarg (3, cldum   ) ;        READ(cldum,*) nlev2
 
-  IF ( chkfile (cf_tfil) .OR. chkfile(cn_fmsk) .OR. chkfile(cn_fzgr)  ) STOP ! missing file
+  IF ( chkfile (cf_tfil) .OR. chkfile(cn_fmsk) .OR. chkfile(cn_fzgr)  ) STOP 99 ! missing file
 
   npiglo = getdim (cf_tfil,cn_x)
   npjglo = getdim (cf_tfil,cn_y)

--- a/src/cdfhdy3d.f90
+++ b/src/cdfhdy3d.f90
@@ -75,7 +75,7 @@ PROGRAM cdfhdy3d
      PRINT *,'     SEE ALSO :'
      PRINT *,'      cdfhdy' 
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_tfil)
@@ -85,7 +85,7 @@ PROGRAM cdfhdy3d
   npk    = getdim (cf_tfil,cn_z)
   npt    = getdim (cf_tfil,cn_t)
   
-  IF ( chkfile(cf_tfil) .OR. chkfile(cn_fmsk) .OR. chkfile(cn_fzgr) ) STOP ! missing files
+  IF ( chkfile(cf_tfil) .OR. chkfile(cn_fmsk) .OR. chkfile(cn_fzgr) ) STOP 99 ! missing files
 
   ipk(:)                       = npk
   stypvar(1)%cname             = cv_out

--- a/src/cdfheatc.f90
+++ b/src/cdfheatc.f90
@@ -86,7 +86,7 @@ PROGRAM cdfheatc
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : to be done ....'
      PRINT *,'       Standard output'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1 
@@ -96,7 +96,7 @@ PROGRAM cdfheatc
   lchk = chkfile(cn_fzgr) .OR. lchk
   lchk = chkfile(cn_fmsk) .OR. lchk
   lchk = chkfile(cf_tfil) .OR. lchk
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   DO WHILE ( ijarg <= narg ) 
      CALL getarg ( ijarg, cldum) ; ijarg = ijarg + 1

--- a/src/cdfhflx.f90
+++ b/src/cdfhflx.f90
@@ -87,7 +87,7 @@ PROGRAM cdfhflx
      PRINT *,'       ASCII file  : ', TRIM(cf_out  )
      PRINT *,'       netcdf file : ', TRIM(cf_outnc) 
      PRINT *,'         variables : hflx_glo, [hflx_atl, hflx_inp, hflx_pac, hflx_ind]'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_tfil)
@@ -95,7 +95,7 @@ PROGRAM cdfhflx
   lchk = chkfile(cn_fhgr)
   lchk = chkfile(cn_fmsk) .OR. lchk
   lchk = chkfile(cf_tfil) .OR. lchk
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   npiglo = getdim (cf_tfil,cn_x)
   npjglo = getdim (cf_tfil,cn_y)

--- a/src/cdfhgradb.f90
+++ b/src/cdfhgradb.f90
@@ -102,7 +102,7 @@ PROGRAM cdfhgradb
       PRINT *,'     SEE ALSO :'
       PRINT *,'        cdfbuoyflx  '
       PRINT *,'      '
-      STOP
+      STOP 99
    ENDIF
 
    ijarg =1 
@@ -121,7 +121,7 @@ PROGRAM cdfhgradb
      CASE DEFAULT
        PRINT *, 'Option ',TRIM(cldum),' not understood !'
        PRINT *, 'Check usage with cdfhgradb (no argument).'
-       STOP
+       STOP 99
      END SELECT
    ENDDO
 
@@ -130,7 +130,7 @@ PROGRAM cdfhgradb
    lchk = ( lchk .OR. chkfile(cn_fhgr) )
    lchk = ( lchk .OR. chkfile(cn_fzgr) )
    lchk = ( lchk .OR. chkfile(cn_fmsk) )
-   IF (lchk ) STOP ! missing file
+   IF (lchk ) STOP 99 ! missing file
 
    npiglo = getdim (cf_tfil, cn_x)
    npjglo = getdim (cf_tfil, cn_y)

--- a/src/cdficediags.f90
+++ b/src/cdficediags.f90
@@ -133,7 +133,7 @@ PROGRAM cdficediag
      PRINT *,'               N = northern hemisphere'
      PRINT *,'               S = southern hemisphere'
      PRINT *,'       standard output'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_ifil)
@@ -164,7 +164,7 @@ PROGRAM cdficediag
   lchk = lchk .OR. chkfile(cn_fmsk)
   lchk = lchk .OR. chkfile(cf_ifil)
 
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   npiglo = getdim (cf_ifil,cn_x)
   npjglo = getdim (cf_ifil,cn_y)
@@ -250,7 +250,7 @@ PROGRAM cdficediag
      tmask(:,npjglo)=0.
   CASE DEFAULT
      PRINT *,' Nperio=', nperio,' not yet coded'
-     STOP
+     STOP 99
   END SELECT
 
   ricethick(:,:)=0.
@@ -269,7 +269,7 @@ PROGRAM cdficediag
      PRINT *,' '
   END IF
 
-  IF (chkvar(cf_ifil, cn_ileadfra)) STOP
+  IF (chkvar(cf_ifil, cn_ileadfra)) STOP 99
   !
   DO jt = 1, npt
      IF (TRIM(cn_iicethic) .NE. 'missing') ricethick(:,:) = getvar(cf_ifil, cn_iicethic, 1, npiglo, npjglo, ktime=jt)

--- a/src/cdfimprovechk.f90
+++ b/src/cdfimprovechk.f90
@@ -77,7 +77,7 @@ PROGRAM cdfimprovechk
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : same as input variable.'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cv_in )
@@ -85,7 +85,7 @@ PROGRAM cdfimprovechk
   CALL getarg (3, cf_ref)
   CALL getarg (4, cf_tst)
 
-  IF ( chkfile(cf_obs) .OR. chkfile(cf_ref) .OR. chkfile(cf_tst) ) STOP ! missing files
+  IF ( chkfile(cf_obs) .OR. chkfile(cf_ref) .OR. chkfile(cf_tst) ) STOP 99 ! missing files
 
   npiglo = getdim(cf_ref, cn_x)
   npjglo = getdim(cf_ref, cn_y)

--- a/src/cdfinfo.f90
+++ b/src/cdfinfo.f90
@@ -58,7 +58,7 @@ PROGRAM cdfinfo
      PRINT *,'        On standard ouput, gives the size of the domain, the depth '
      PRINT *,'        dimension name, the number of variables.'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_in)
@@ -71,7 +71,7 @@ PROGRAM cdfinfo
      END SELECT
   ENDDO
         
-  IF ( chkfile(cf_in) ) STOP ! missing file
+  IF ( chkfile(cf_in) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_in,cn_x)
   npjglo = getdim (cf_in,cn_y)

--- a/src/cdfio.F90
+++ b/src/cdfio.F90
@@ -406,7 +406,7 @@ CONTAINS
              iidims(1) = nid_t 
           ELSE
              PRINT *,' ERROR: ipk = ',kpk(jv), jv , sdtyvar(jv)%cname
-             STOP
+             STOP 98
           ENDIF
     
           SELECT CASE ( sdtyvar(jv)%cprecision ) ! check the precision of the variable to create
@@ -553,22 +553,22 @@ CONTAINS
 
     puttimeatt=NF90_INQ_VARID(kout, cdvartime, ivarid)
     IF (puttimeatt /= 0 ) THEN 
-      PRINT *, NF90_STRERROR(puttimeatt)  ; STOP 'puttimeatt var does not exist'
+      PRINT *, NF90_STRERROR(puttimeatt)  ; PRINT *, 'puttimeatt var does not exist' ; STOP 98
     ENDIF
    
     puttimeatt = NF90_REDEF(kout)
     puttimeatt=NF90_PUT_ATT(kout,ivarid,'calendar',ctcalendar)
-    IF (puttimeatt /= 0 ) THEN ;PRINT *, NF90_STRERROR(puttimeatt)  ; STOP 'puttimeatt calendar'; ENDIF
+    IF (puttimeatt /= 0 ) THEN ;PRINT *, NF90_STRERROR(puttimeatt)  ; PRINT *, 'puttimeatt calendar'  ; STOP 98 ; ENDIF
     puttimeatt=NF90_PUT_ATT(kout,ivarid,'title',cttitle)
-    IF (puttimeatt /= 0 ) THEN ;PRINT *, NF90_STRERROR(puttimeatt)  ; STOP 'puttimeatt title'; ENDIF
+    IF (puttimeatt /= 0 ) THEN ;PRINT *, NF90_STRERROR(puttimeatt)  ; PRINT *, 'puttimeatt title'     ; STOP 98 ; ENDIF
     puttimeatt=NF90_PUT_ATT(kout,ivarid,'long_name',ctlong_name)
-    IF (puttimeatt /= 0 ) THEN ;PRINT *, NF90_STRERROR(puttimeatt)  ; STOP 'puttimeatt long_name'; ENDIF
+    IF (puttimeatt /= 0 ) THEN ;PRINT *, NF90_STRERROR(puttimeatt)  ; PRINT *, 'puttimeatt long_name' ; STOP 98 ; ENDIF
     puttimeatt=NF90_PUT_ATT(kout,ivarid,'axis',ctaxis)
-    IF (puttimeatt /= 0 ) THEN ;PRINT *, NF90_STRERROR(puttimeatt)  ; STOP 'puttimeatt axis'; ENDIF
+    IF (puttimeatt /= 0 ) THEN ;PRINT *, NF90_STRERROR(puttimeatt)  ; PRINT *, 'puttimeatt axis'      ; STOP 98 ; ENDIF
     puttimeatt=NF90_PUT_ATT(kout,ivarid,'units',ctunits)
-    IF (puttimeatt /= 0 ) THEN ;PRINT *, NF90_STRERROR(puttimeatt)  ; STOP 'puttimeatt units'; ENDIF
+    IF (puttimeatt /= 0 ) THEN ;PRINT *, NF90_STRERROR(puttimeatt)  ; PRINT *, 'puttimeatt units'     ; STOP 98 ; ENDIF
     puttimeatt=NF90_PUT_ATT(kout,ivarid,'time_origin',cttime_origin)
-    IF (puttimeatt /= 0 ) THEN ;PRINT *, NF90_STRERROR(puttimeatt)  ; STOP 'puttimeatt time_origin'; ENDIF
+    IF (puttimeatt /= 0 ) THEN ;PRINT *, NF90_STRERROR(puttimeatt)  ; PRINT *,'puttimeatt time_origin'; STOP 98 ; ENDIF
 
     puttimeatt=NF90_ENDDEF(kout)
 
@@ -621,7 +621,7 @@ CONTAINS
     CHARACTER(LEN=*), OPTIONAL, INTENT(in) :: cdglobal   !: global attribute
     !!----------------------------------------------------------------------
     putatt=NF90_PUT_ATT(kout,kid,'units',sdtyvar%cunits) 
-    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt units'; ENDIF
+    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt units'; STOP 98; ENDIF
 
     ! With netcdf4, missing value must have the same precision than the variable. Need to convert
     ! to sdtyvar%cprecision previous PUT_ATT
@@ -631,35 +631,35 @@ CONTAINS
     CASE ( 'by' ) ; putatt=NF90_PUT_ATT(kout,kid,cn_missing_value, INT(sdtyvar%rmissing_value,1) )  
     CASE DEFAULT  ; putatt=NF90_PUT_ATT(kout,kid,cn_missing_value,REAL(sdtyvar%rmissing_value,4) )
     END SELECT
-    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt missing value'; ENDIF
+    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt missing value'; STOP 98; ENDIF
 
     putatt=NF90_PUT_ATT(kout,kid,'valid_min',sdtyvar%valid_min) 
-    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt valid_min'; ENDIF
+    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt valid_min'    ; STOP 98; ENDIF
     putatt=NF90_PUT_ATT(kout,kid,'valid_max',sdtyvar%valid_max)
-    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt valid_max'; ENDIF
+    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt valid_max'    ; STOP 98; ENDIF
     putatt=NF90_PUT_ATT(kout,kid,'long_name',sdtyvar%clong_name)
-    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt longname'; ENDIF
+    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt longname'     ; STOP 98; ENDIF
     putatt=NF90_PUT_ATT(kout,kid,'short_name',sdtyvar%cshort_name) 
-    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt short name'; ENDIF
+    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt short name'   ; STOP 98; ENDIF
     putatt=NF90_PUT_ATT(kout,kid,'iweight',sdtyvar%iwght) 
-    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt iweight'; ENDIF
+    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt iweight'      ; STOP 98; ENDIF
     putatt=NF90_PUT_ATT(kout,kid,'online_operation',sdtyvar%conline_operation) 
-    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt online oper'; ENDIF
+    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt online oper'  ; STOP 98; ENDIF
     putatt=NF90_PUT_ATT(kout,kid,'axis',sdtyvar%caxis) 
-    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt axis'; ENDIF
+    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt axis'         ; STOP 98; ENDIF
 
     ! Optional attributes (scale_factor, add_offset )
     putatt=NF90_PUT_ATT(kout,kid,'scale_factor',sdtyvar%scale_factor) 
-    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt scale fact'; ENDIF
+    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt scale fact'; STOP 98; ENDIF
     putatt=NF90_PUT_ATT(kout,kid,'add_offset',sdtyvar%add_offset) 
-    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt add offset'; ENDIF
+    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt add offset'; STOP 98; ENDIF
     putatt=NF90_PUT_ATT(kout,kid,'savelog10',sdtyvar%savelog10) 
-    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt savelog0'; ENDIF
+    IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt savelog0'  ; STOP 98; ENDIF
 
     ! Global attribute
     IF ( PRESENT(cdglobal) ) THEN
       putatt=NF90_PUT_ATT(kout,NF90_GLOBAL,'history',cdglobal)
-      IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; STOP 'putatt global'; ENDIF
+      IF (putatt /= NF90_NOERR ) THEN ;PRINT *, NF90_STRERROR(putatt)  ; PRINT *, 'putatt global'  ; STOP 98; ENDIF
     ENDIF
 
   END FUNCTION putatt
@@ -719,7 +719,7 @@ CONTAINS
     istatus = NF90_INQ_VARID(incid, cdvar, idvar)
     IF ( istatus /= NF90_NOERR ) THEN
        PRINT *, NF90_STRERROR(istatus),' in atted ( inq_varid)'
-       STOP
+       STOP 98
     ENDIF
     istatus = NF90_INQUIRE_ATTRIBUTE(incid, idvar, cdatt, xtype=ityp )
     IF ( istatus /= NF90_NOERR ) THEN
@@ -734,7 +734,7 @@ CONTAINS
          atted_char = istatus
        ELSE
          PRINT *, ' Mismatch in attribute type in atted_char'
-         STOP
+         STOP 98
        ENDIF
     ENDIF
     istatus=NF90_CLOSE(incid)
@@ -762,7 +762,7 @@ CONTAINS
     istatus = NF90_INQ_VARID(incid, cdvar, idvar)
     IF ( istatus /= NF90_NOERR ) THEN
        PRINT *, NF90_STRERROR(istatus),' in atted ( inq_varid)'
-       STOP
+       STOP 98
     ENDIF
     istatus = NF90_INQUIRE_ATTRIBUTE(incid, idvar, cdatt, xtype=ityp )
     IF ( istatus /= NF90_NOERR ) THEN
@@ -777,7 +777,7 @@ CONTAINS
          atted_r4 = istatus
        ELSE
          PRINT *, ' Mismatch in attribute type in atted_r4'
-         STOP
+         STOP 98
        ENDIF
     ENDIF
     istatus=NF90_CLOSE(incid)
@@ -827,7 +827,7 @@ CONTAINS
           istatus=NF90_INQ_DIMID(incid, cdim_name, id_dim)
           IF (istatus /= NF90_NOERR ) THEN
             PRINT *,NF90_STRERROR(istatus)
-            PRINT *,' Exact dimension name ', TRIM(cdim_name),' not found in ',TRIM(cdfile) ; STOP
+            PRINT *,' Exact dimension name ', TRIM(cdim_name),' not found in ',TRIM(cdfile) ; STOP 98
           ENDIF
           istatus=NF90_INQUIRE_DIMENSION(incid, id_dim, len=getdim)
           IF ( PRESENT(cdtrue) ) cdtrue=cdim_name
@@ -1313,31 +1313,31 @@ CONTAINS
 
              istatus=NF90_INQ_VARID (incid,'mbathy', id_var)
              IF ( istatus /=  NF90_NOERR ) THEN
-               PRINT *, 'Problem reading mesh_zgr.nc v3 : no mbathy found !' ; STOP
+               PRINT *, 'Problem reading mesh_zgr.nc v3 : no mbathy found !' ; STOP 98
              ENDIF
              istatus=NF90_GET_VAR(incid,id_var, mbathy, start=(/1,1,1/), count=(/ii,ij,1/) )
              !
              istatus=NF90_INQ_VARID (incid,'e3t_ps', id_var)
              IF ( istatus /=  NF90_NOERR ) THEN
-               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3t_ps found !' ; STOP
+               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3t_ps found !' ; STOP 98
              ENDIF
              istatus=NF90_GET_VAR(incid,id_var,e3t_ps, start=(/1,1,1/), count=(/ii,ij,1/) )
              !
              istatus=NF90_INQ_VARID (incid,'e3w_ps', id_var)
              IF ( istatus /=  NF90_NOERR ) THEN
-               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3w_ps found !' ; STOP
+               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3w_ps found !' ; STOP 98
              ENDIF
              istatus=NF90_GET_VAR(incid,id_var,e3w_ps, start=(/1,1,1/), count=(/ii,ij,1/) )
              !
              istatus=NF90_INQ_VARID (incid,'e3t_0', id_var)
              IF ( istatus /=  NF90_NOERR ) THEN
-               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3t_0 found !' ; STOP
+               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3t_0 found !' ; STOP 98
              ENDIF
              istatus=NF90_GET_VAR(incid,id_var,e3t_0, start=(/1,1/), count=(/ik0,1/) )
              !
              istatus=NF90_INQ_VARID (incid,'e3w_0', id_var)
              IF ( istatus /=  NF90_NOERR ) THEN
-               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3w_0 found !' ; STOP
+               PRINT *, 'Problem reading mesh_zgr.nc v3 : no e3w_0 found !' ; STOP 98
              ENDIF
              istatus=NF90_GET_VAR(incid,id_var,e3w_0, start=(/1,1/), count=(/ik0,1/) )
              DO ji=1,ii
@@ -1558,7 +1558,7 @@ CONTAINS
     IF ( istatus /= 0 ) THEN
        PRINT *,' Problem in getvar for ', TRIM(clvar)
        CALL ERR_HDL(istatus)
-       STOP
+       STOP 98
     ENDIF
 
     ! Caution : order does matter !
@@ -1663,7 +1663,7 @@ CONTAINS
     IF ( istatus /= 0 ) THEN
        PRINT *,' Problem in getvar3d for ', TRIM(cdvar)
        CALL ERR_HDL(istatus)
-       STOP
+       STOP 98
     ENDIF
 
     ! Caution : order does matter !
@@ -1768,7 +1768,7 @@ CONTAINS
     IF ( istatus /= 0 ) THEN
        PRINT *,' Problem in getvar3dt for ', TRIM(cdvar)
        CALL ERR_HDL(istatus)
-       STOP
+       STOP 98
     ENDIF
 
     ! Caution : order does matter !
@@ -1878,7 +1878,7 @@ CONTAINS
     IF ( istatus /= 0 ) THEN
        PRINT *,' Problem in getvar4d for ', TRIM(cdvar)
        CALL ERR_HDL(istatus)
-       STOP
+       STOP 98
     ENDIF
 
     ! Caution : order does matter !
@@ -1983,7 +1983,7 @@ CONTAINS
     IF ( istatus /= 0 ) THEN
        PRINT *,' Problem in getvarxz for ', TRIM(cdvar)
        CALL ERR_HDL(istatus)
-       STOP
+       STOP 98
     ENDIF
 
     ! Caution : order does matter !
@@ -2089,7 +2089,7 @@ CONTAINS
     IF ( istatus /= 0 ) THEN
        PRINT *,' Problem in getvaryz for ', TRIM(cdvar)
        CALL ERR_HDL(istatus)
-       STOP
+       STOP 98
     ENDIF
 
     ! Caution : order does matter !
@@ -2237,7 +2237,7 @@ CONTAINS
        PRINT *,' Problem in getvare3 for ', TRIM(cdvar)
        PRINT *,TRIM(cdfile), kk
        CALL ERR_HDL(istatus)
-       STOP
+       STOP 98
     ENDIF
 
     istatus=NF90_CLOSE(incid)
@@ -2350,7 +2350,7 @@ CONTAINS
              END DO
              IF (jj == jpdep +1 ) THEN
                 PRINT *,' No depth variable found in ', TRIM(cdfile)
-                STOP
+                STOP 98
              ENDIF
           ENDIF
        ENDIF
@@ -2698,7 +2698,7 @@ CONTAINS
        iid = nid_timb
     CASE DEFAULT
        PRINT *, 'E R R O R: CASE ',cdtype,' do not coded'
-       STOP
+       STOP 98
     END SELECT
 
     istart(:) = 1
@@ -2861,7 +2861,7 @@ CONTAINS
     IF (kstatus /=  NF90_NOERR ) THEN
        PRINT *, 'ERROR in NETCDF routine, status=',kstatus
        PRINT *,NF90_STRERROR(kstatus)
-       STOP
+       STOP 98
     END IF
 
   END SUBROUTINE ERR_HDL
@@ -2937,7 +2937,7 @@ CONTAINS
     ELSE 
        PRINT *,'  ERROR : variable ',TRIM(cdvar),' has ', indim, &
             &       ' dimensions !. Only 3 or 4 supported'
-       STOP
+       STOP 98
     ENDIF
 
     ! convert to physical values
@@ -2965,7 +2965,7 @@ CONTAINS
     !!               Do nothing is filename is 'none'
     !!
     !! ** Method  : Doing it this way allow statements such as
-    !!              IF ( chkfile( cf_toto) ) STOP  ! missing file
+    !!              IF ( chkfile( cf_toto) ) STOP 99 ! missing file
     !!
     !!----------------------------------------------------------------------
     CHARACTER(LEN=*),  INTENT(in) :: cd_file
@@ -3003,7 +3003,7 @@ CONTAINS
     !!               Do nothing is varname is 'none'
     !!
     !! ** Method  : Doing it this way allow statements such as
-    !!              IF ( chkvar( cf_toto, cv_toto) ) STOP  ! missing var
+    !!              IF ( chkvar( cf_toto, cv_toto) ) STOP 99 ! missing var
     !!
     !!----------------------------------------------------------------------
     CHARACTER(LEN=*), INTENT(in) :: cd_file
@@ -3125,7 +3125,7 @@ CONTAINS
           IF ( GetNcFile%idimids(jvar,4) /= GetNcFile%iunlim ) THEN
              PRINT *, ' 4D variables must have an unlimited time dimension ...'
              PRINT *, ' Cannot process this file :', TRIM(cd_file)
-             STOP
+             STOP 98
           ENDIF
           idt = GetNcFile%idimids(jvar,4) 
        ENDIF
@@ -3139,7 +3139,7 @@ CONTAINS
 
     IF ( idx == -1 .OR. idy == -1 ) THEN 
        PRINT *, ' ERROR : no x, y dimensions found'
-       STOP
+       STOP 98
     ENDIF
 
     ! get dimensions

--- a/src/cdfisopsi.f90
+++ b/src/cdfisopsi.f90
@@ -82,14 +82,14 @@ PROGRAM cdfisopsi
      PRINT *,'         Output on ',TRIM(cf_out),' variable soisopsi'
      PRINT *,'         Depths are taken from input file '
      PRINT *,'         requires ',TRIM(cn_fhgr),' and ',TRIM(cn_fzgr) 
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cldum) ; READ (cldum,*) refdepth
   CALL getarg (2, cldum) ; READ (cldum,*) zsigmaref
   CALL getarg (3, cf_tfil)
 
-  IF ( chkfile(cf_tfil) .OR. chkfile(cn_fzgr) .OR. chkfile(cn_fhgr) ) STOP  ! missing file
+  IF ( chkfile(cf_tfil) .OR. chkfile(cn_fzgr) .OR. chkfile(cn_fhgr) ) STOP 99 ! missing file
 
   PRINT *, 'Potential density referenced at ', refdepth , ' meters'
   PRINT *, 'Isopycn for projection is ', zsigmaref

--- a/src/cdfkempemekeepe.f90
+++ b/src/cdfkempemekeepe.f90
@@ -52,12 +52,12 @@ PROGRAM cdfkempemekeepe
      PRINT *,'     the mean must have been computed on a period long enough'
      PRINT *,'     for the statistics to be meaningful'
      PRINT *,'                         '
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg(1, cf_uvwtfil)
 
-  IF (chkfile(cf_uvwtfil) ) STOP ! missing file
+  IF (chkfile(cf_uvwtfil) ) STOP 99 ! missing file
   npiglo = getdim(cf_uvwtfil, cn_x)
   npjglo = getdim(cf_uvwtfil, cn_y)
   npk    = getdim(cf_uvwtfil, cn_z)

--- a/src/cdflap.f90
+++ b/src/cdflap.f90
@@ -102,7 +102,7 @@ PROGRAM cdflap
      PRINT *,'       variable is lap<var>overf2'
     
 
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1 ; ii=0
@@ -123,7 +123,7 @@ PROGRAM cdflap
         CASE ( 3 ) ; ct_in = cldum
         CASE DEFAULT
           PRINT *,' Too many free arguments ...'
-          STOP
+          STOP 99
         END SELECT
      END SELECT
   ENDDO
@@ -137,7 +137,7 @@ PROGRAM cdflap
     lchk = chkfile (cn_fmsk) .OR. lchk
   ENDIF
   lchk = chkfile (cf_in  ) .OR. lchk
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   npiglo = getdim(cf_in,cn_x)
   npjglo = getdim(cf_in,cn_y)
@@ -225,7 +225,7 @@ PROGRAM cdflap
       cv_lat  =cn_gphif
   CASE DEFAULT
       PRINT *, ' TYPE ', TRIM(ct_in),' unknown on C-grid'
-      STOP
+      STOP 99
   END SELECT
       
 

--- a/src/cdflinreg.f90
+++ b/src/cdflinreg.f90
@@ -85,12 +85,12 @@ PROGRAM cdflinreg
      PRINT *,'                - slope coefficient'
      PRINT *,'                - barycenter '
      PRINT *,'                - Pearson Coefficient'
-     STOP
+     STOP 99
   ENDIF
 
   !! Initialisation from 1st file (all file are assume to have the same geometry)
   CALL getarg (1, cf_in )
-  IF ( chkfile(cf_in) ) STOP ! missing file
+  IF ( chkfile(cf_in) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_in,cn_x                             )
   npjglo = getdim (cf_in,cn_y                             )
@@ -209,7 +209,7 @@ PROGRAM cdflinreg
            DO jfil = 1, narg
               CALL getarg (jfil, cf_in)
               IF ( jvar == 1 ) THEN
-                  IF ( chkfile(cf_in) ) STOP ! missing file
+                  IF ( chkfile(cf_in) ) STOP 99 ! missing file
               ENDIF
               npt = getdim (cf_in,cn_t)
               ntframe=ntframe+npt

--- a/src/cdfmaskdmp.f90
+++ b/src/cdfmaskdmp.f90
@@ -98,18 +98,18 @@ PROGRAM cdfmaskdmp
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : wdmp'
-     STOP
+     STOP 99
   ENDIF
 
   IF ( narg > 2 .AND. narg < 9 ) THEN
      PRINT *,'wrong number of arguments'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_tfil)
   CALL getarg (2, cf_sfil)
 
-  IF ( chkfile(cf_tfil) .OR. chkfile(cf_sfil) .OR. chkfile(cn_fmsk) ) STOP ! missing files
+  IF ( chkfile(cf_tfil) .OR. chkfile(cf_sfil) .OR. chkfile(cn_fmsk) ) STOP 99 ! missing files
 
   IF ( narg == 9 ) THEN
      CALL getarg (3, cldum) ; READ(cldum,*) ref_dep

--- a/src/cdfmax.f90
+++ b/src/cdfmax.f90
@@ -83,7 +83,7 @@ PROGRAM cdfmax
      PRINT *,'      '
      PRINT *,'     OUTPUT : '
      PRINT *,'       output is done on standard output.'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg=1
@@ -111,11 +111,11 @@ PROGRAM cdfmax
         lforcexy = .TRUE.
      CASE DEFAULT
         PRINT *, cldum,' : unknown option '
-        STOP
+        STOP 99
      END SELECT
   END DO
 
-  IF ( chkfile(cf_in) ) STOP ! missing file
+  IF ( chkfile(cf_in) ) STOP 99 ! missing file
 
   ni=0 ; nj=0; nk=0; nt=0 
 
@@ -123,7 +123,7 @@ PROGRAM cdfmax
   IF ( istatus == 1 ) THEN 
      ni = getdim(cf_in, 'lon', cldum, istatus)
      IF ( istatus == 1 ) THEN
-        PRINT *,' No X or lon dim found ' ; STOP
+        PRINT *,' No X or lon dim found ' ; STOP 99
      ENDIF
   ENDIF
   IF ( iimax == 0 ) iimax = ni
@@ -132,7 +132,7 @@ PROGRAM cdfmax
   IF ( istatus == 1 ) THEN 
      nj = getdim(cf_in, 'lat', cldum, istatus)
      IF ( istatus == 1 ) THEN
-        PRINT *,' No y or lat dim found ' ; STOP
+        PRINT *,' No y or lat dim found ' ; STOP 99
      ENDIF
   ENDIF
   IF ( ijmax == 0 ) ijmax = nj
@@ -282,7 +282,7 @@ PROGRAM cdfmax
         END SELECT
 
      CASE DEFAULT
-        PRINT *,' ntype = ',ntype, '  is not defined ' ; STOP
+        PRINT *,' ntype = ',ntype, '  is not defined ' ; STOP 99
      END SELECT ! ntype
   ENDDO
 

--- a/src/cdfmaxmoc.f90
+++ b/src/cdfmaxmoc.f90
@@ -84,7 +84,7 @@ PROGRAM cdfmaxmoc
      PRINT *,'     SEE ALSO :'
      PRINT *,'       cdfmoc '
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg(1, cf_moc)                          ! input moc file
@@ -94,7 +94,7 @@ PROGRAM cdfmaxmoc
   CALL getarg(5, cldum ) ; READ(cldum,*) rdepmin  ! searching window : depth min
   CALL getarg(6, cldum ) ; READ(cldum,*) rdepmax  ! searching window : depth max
   
-  IF ( chkfile(cf_moc) ) STOP ! missing file
+  IF ( chkfile(cf_moc) ) STOP 99 ! missing file
 
   npjglo = getdim(cf_moc, cn_y)
   npk    = getdim(cf_moc, cn_z)
@@ -109,7 +109,7 @@ PROGRAM cdfmaxmoc
   CASE ('pac') ; cv_in=cn_zomsfpac
   CASE ('inp') ; cv_in=cn_zomsfinp
   CASE ('ind') ; cv_in=cn_zomsfind
-  CASE DEFAULT ; STOP 'basin not found'
+  CASE DEFAULT ; PRINT *, 'basin not found' ; STOP 99
   END SELECT
 
   ALLOCATE ( stypvar(nvarout), ipk(nvarout), id_varout(nvarout) )

--- a/src/cdfmean.f90
+++ b/src/cdfmean.f90
@@ -128,7 +128,7 @@ PROGRAM cdfmean
      PRINT *,'       - ASCII files : ', TRIM(cf_out) 
      PRINT *,'                       [ ',TRIM(cf_var),', in case of -var ]'
      PRINT *,'       - all output on ASCII files are also sent to standard output.'
-     STOP
+     STOP 99
   ENDIF
 
   ! Open standard output with recl=256 to avoid wrapping of long lines (ifort)
@@ -161,7 +161,7 @@ PROGRAM cdfmean
         CASE ( 9 ) ; READ(cldum,*) ikmax
         CASE DEFAULT 
           PRINT *, '  ERROR : Too many arguments ...'
-          STOP
+          STOP 99
         END SELECT
      END SELECT
   END DO
@@ -170,7 +170,7 @@ PROGRAM cdfmean
   lchk = chkfile(cn_fzgr) .OR. lchk
   lchk = chkfile(cn_fmsk) .OR. lchk
   lchk = chkfile(cf_in  ) .OR. lchk
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   cv_dep   = 'none'
   npiglo = getdim (cf_in, cn_x)
@@ -258,7 +258,7 @@ PROGRAM cdfmean
      cv_dep   = cn_gdepw
   CASE DEFAULT
      PRINT *, 'this type of variable is not known :', TRIM(ctype)
-     STOP
+     STOP 99
   END SELECT
 
   e1(:,:) = getvar  (cn_fhgr, cv_e1,  1,  npiglo, npjglo, kimin=iimin, kjmin=ijmin)

--- a/src/cdfmeshmask.f90
+++ b/src/cdfmeshmask.f90
@@ -146,7 +146,7 @@ PROGRAM cdfmeshmask
      PRINT *,'     SEE ALSO :'
      PRINT *,'       '
      PRINT *,'      '
-      STOP 99
+     STOP 99
   ENDIF
 
   ijarg=1
@@ -167,7 +167,7 @@ PROGRAM cdfmeshmask
   lchk = lchk .OR. chkfile(cf_nam) 
   lchk = lchk .OR. chkfile(cf_bat) 
   lchk = lchk .OR. chkfile(cf_coo) 
-  IF ( lchk )  STOP 99 ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   npiglo = getdim(cf_coo, cn_x)
   npjglo = getdim(cf_coo, cn_y)
@@ -393,12 +393,12 @@ CONTAINS
           ENDDO
           IF ( ik == 1 ) THEN
              ierr = NF90_PUT_VAR( ncmsk, id_umsku, umask(:,:,1),    start=(/1,1,1/), count=(/npiglo,npjglo,1/) )
-             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
              ENDIF
           ENDIF
        ENDDO
        ierr = NF90_PUT_VAR( ncmsk, id_umsk, umask,    start=(/1,1,nkbloct(jbloc),1/), count=(/npiglo,npjglo,nbloc_sz,1/) )
-       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
        ENDIF
        DEALLOCATE ( tmask , umask)
     ENDDO
@@ -424,12 +424,12 @@ CONTAINS
           ENDDO
           IF ( ik == 1 ) THEN
              ierr = NF90_PUT_VAR( ncmsk, id_vmsku, vmask(:,:,1),    start=(/1,1,1/), count=(/npiglo,npjglo,1/) )
-             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
              ENDIF
           ENDIF
        ENDDO
        ierr = NF90_PUT_VAR( ncmsk, id_vmsk, vmask,    start=(/1,1,nkbloct(jbloc),1/), count=(/npiglo,npjglo,nbloc_sz,1/) )
-       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
        ENDIF
        DEALLOCATE ( tmask , vmask)
     ENDDO
@@ -457,12 +457,12 @@ CONTAINS
           ENDDO
           IF ( ik == 1 ) THEN
              ierr = NF90_PUT_VAR( ncmsk, id_fmsku, fmask(:,:,1),    start=(/1,1,1/), count=(/npiglo,npjglo,1/) )
-             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
              ENDIF
           ENDIF
        ENDDO
        ierr = NF90_PUT_VAR( ncmsk, id_fmsk, fmask,    start=(/1,1,nkbloct(jbloc),1/), count=(/npiglo,npjglo,nbloc_sz,1/) )
-       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
        ENDIF
        DEALLOCATE ( tmask , fmask)
     ENDDO
@@ -769,74 +769,74 @@ CONTAINS
     !	byte fmask(t, z, y, x) ;
 
     ierr= NF90_CREATE(cf_msk, or(NF90_CLOBBER,NF90_NETCDF4), ncmsk) 
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr= NF90_DEF_DIM(ncmsk, 'x', npiglo, idx)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr= NF90_DEF_DIM(ncmsk, 'y', npjglo, idy)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr= NF90_DEF_DIM(ncmsk, 'z', jpk,    idz)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr= NF90_DEF_DIM(ncmsk, 't', NF90_UNLIMITED,  idt)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
 
     ierr=NF90_DEF_VAR(ncmsk, 'nav_lon',       NF90_FLOAT, (/idx,idy/), id_navlon )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'nav_lat',       NF90_FLOAT, (/idx,idy/), id_navlat )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'nav_lev',       NF90_FLOAT, (/idz/)    , id_navlev )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'time_counter',  NF90_FLOAT, (/idt/)    , id_time   )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
 
     ierr=NF90_DEF_VAR(ncmsk, 'tmaskutil',    NF90_BYTE, (/idx,idy,idt/), id_tmsku )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'umaskutil',    NF90_BYTE, (/idx,idy,idt/), id_umsku )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'vmaskutil',    NF90_BYTE, (/idx,idy,idt/), id_vmsku )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'fmaskutil',    NF90_BYTE, (/idx,idy,idt/), id_fmsku )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
 
     ierr=NF90_DEF_VAR(ncmsk, 'tmask',         NF90_BYTE, (/idx,idy,idz,idt/), id_tmsk )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ; 
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ; 
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'umask',         NF90_BYTE, (/idx,idy,idz,idt/), id_umsk )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'vmask',         NF90_BYTE, (/idx,idy,idz,idt/), id_vmsk )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'fmask',         NF90_BYTE, (/idx,idy,idz,idt/), id_fmsk )
 
     ierr = NF90_ENDDEF(ncmsk)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ; 
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ; 
     ENDIF
     ! put dimension related variables
 
     ierr = NF90_PUT_VAR(ncmsk, id_navlon, rlon)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr = NF90_PUT_VAR(ncmsk, id_navlat, rlat)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr = NF90_PUT_VAR(ncmsk, id_navlev, gdept_1d )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
     ierr = NF90_PUT_VAR(ncmsk, id_time  , (/0./) )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP 99 ;
     ENDIF
 
   END SUBROUTINE CreateMaskFile

--- a/src/cdfmeshmask.f90
+++ b/src/cdfmeshmask.f90
@@ -146,7 +146,7 @@ PROGRAM cdfmeshmask
      PRINT *,'     SEE ALSO :'
      PRINT *,'       '
      PRINT *,'      '
-     STOP
+      STOP 99
   ENDIF
 
   ijarg=1
@@ -167,7 +167,7 @@ PROGRAM cdfmeshmask
   lchk = lchk .OR. chkfile(cf_nam) 
   lchk = lchk .OR. chkfile(cf_bat) 
   lchk = lchk .OR. chkfile(cf_coo) 
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk )  STOP 99 ! missing files
 
   npiglo = getdim(cf_coo, cn_x)
   npjglo = getdim(cf_coo, cn_y)
@@ -362,12 +362,12 @@ CONTAINS
           END DO
           IF ( ik == 1 ) THEN
              ierr = NF90_PUT_VAR( ncmsk, id_tmsku, tmask(:,:,1),    start=(/1,1,1/), count=(/npiglo,npjglo,1/) )
-             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
              ENDIF
           ENDIF
        ENDDO
        ierr = NF90_PUT_VAR( ncmsk, id_tmsk, tmask,    start=(/1,1,nkbloct(jbloc),1/), count=(/npiglo,npjglo,nbloc_sz,1/) )
-       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ; 
+       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ; 
        ENDIF
        DEALLOCATE ( tmask )
     ENDDO ! bloc
@@ -393,12 +393,12 @@ CONTAINS
           ENDDO
           IF ( ik == 1 ) THEN
              ierr = NF90_PUT_VAR( ncmsk, id_umsku, umask(:,:,1),    start=(/1,1,1/), count=(/npiglo,npjglo,1/) )
-             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
              ENDIF
           ENDIF
        ENDDO
        ierr = NF90_PUT_VAR( ncmsk, id_umsk, umask,    start=(/1,1,nkbloct(jbloc),1/), count=(/npiglo,npjglo,nbloc_sz,1/) )
-       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
        ENDIF
        DEALLOCATE ( tmask , umask)
     ENDDO
@@ -424,12 +424,12 @@ CONTAINS
           ENDDO
           IF ( ik == 1 ) THEN
              ierr = NF90_PUT_VAR( ncmsk, id_vmsku, vmask(:,:,1),    start=(/1,1,1/), count=(/npiglo,npjglo,1/) )
-             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
              ENDIF
           ENDIF
        ENDDO
        ierr = NF90_PUT_VAR( ncmsk, id_vmsk, vmask,    start=(/1,1,nkbloct(jbloc),1/), count=(/npiglo,npjglo,nbloc_sz,1/) )
-       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
        ENDIF
        DEALLOCATE ( tmask , vmask)
     ENDDO
@@ -457,12 +457,12 @@ CONTAINS
           ENDDO
           IF ( ik == 1 ) THEN
              ierr = NF90_PUT_VAR( ncmsk, id_fmsku, fmask(:,:,1),    start=(/1,1,1/), count=(/npiglo,npjglo,1/) )
-             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+             IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
              ENDIF
           ENDIF
        ENDDO
        ierr = NF90_PUT_VAR( ncmsk, id_fmsk, fmask,    start=(/1,1,nkbloct(jbloc),1/), count=(/npiglo,npjglo,nbloc_sz,1/) )
-       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+       IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
        ENDIF
        DEALLOCATE ( tmask , fmask)
     ENDDO
@@ -669,7 +669,7 @@ CONTAINS
     ELSE
        PRINT *, '    e r r o r'
        PRINT *, '    parameter , nperio = ', nperio
-       STOP ' '
+        STOP 99
     ENDIF
 
     ! write mbathy to file mesh_zgr
@@ -769,74 +769,74 @@ CONTAINS
     !	byte fmask(t, z, y, x) ;
 
     ierr= NF90_CREATE(cf_msk, or(NF90_CLOBBER,NF90_NETCDF4), ncmsk) 
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr= NF90_DEF_DIM(ncmsk, 'x', npiglo, idx)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr= NF90_DEF_DIM(ncmsk, 'y', npjglo, idy)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr= NF90_DEF_DIM(ncmsk, 'z', jpk,    idz)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr= NF90_DEF_DIM(ncmsk, 't', NF90_UNLIMITED,  idt)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
 
     ierr=NF90_DEF_VAR(ncmsk, 'nav_lon',       NF90_FLOAT, (/idx,idy/), id_navlon )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'nav_lat',       NF90_FLOAT, (/idx,idy/), id_navlat )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'nav_lev',       NF90_FLOAT, (/idz/)    , id_navlev )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'time_counter',  NF90_FLOAT, (/idt/)    , id_time   )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
 
     ierr=NF90_DEF_VAR(ncmsk, 'tmaskutil',    NF90_BYTE, (/idx,idy,idt/), id_tmsku )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'umaskutil',    NF90_BYTE, (/idx,idy,idt/), id_umsku )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'vmaskutil',    NF90_BYTE, (/idx,idy,idt/), id_vmsku )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'fmaskutil',    NF90_BYTE, (/idx,idy,idt/), id_fmsku )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
 
     ierr=NF90_DEF_VAR(ncmsk, 'tmask',         NF90_BYTE, (/idx,idy,idz,idt/), id_tmsk )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ; 
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ; 
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'umask',         NF90_BYTE, (/idx,idy,idz,idt/), id_umsk )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'vmask',         NF90_BYTE, (/idx,idy,idz,idt/), id_vmsk )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr=NF90_DEF_VAR(ncmsk, 'fmask',         NF90_BYTE, (/idx,idy,idz,idt/), id_fmsk )
 
     ierr = NF90_ENDDEF(ncmsk)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ; 
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ; 
     ENDIF
     ! put dimension related variables
 
     ierr = NF90_PUT_VAR(ncmsk, id_navlon, rlon)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr = NF90_PUT_VAR(ncmsk, id_navlat, rlat)
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr = NF90_PUT_VAR(ncmsk, id_navlev, gdept_1d )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
     ierr = NF90_PUT_VAR(ncmsk, id_time  , (/0./) )
-    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ; STOP ;
+    IF ( ierr /= NF90_NOERR ) THEN  ; PRINT *, NF90_STRERROR(ierr) ;  STOP 99 ;
     ENDIF
 
   END SUBROUTINE CreateMaskFile

--- a/src/cdfmhst.f90
+++ b/src/cdfmhst.f90
@@ -144,7 +144,7 @@ PROGRAM cdfmhst
      PRINT *,'                       ', TRIM(cv_zomht),cbasin(jbasins),' : Meridional Heat Transport'
      PRINT *,'                     [ ', TRIM(cv_zomst),cbasin(jbasins),' : Meridional Salt Transport ]'
               END DO
-     STOP
+     STOP 99
   ENDIF
 
   npvar   = 1    ! default value ( no MST output)
@@ -170,7 +170,7 @@ PROGRAM cdfmhst
 
   ! security check
   SELECT CASE (ifile )
-  CASE ( 0 ) ; PRINT *, ' You must provide at least 1 file name (VT) ' ; STOP
+  CASE ( 0 ) ; PRINT *, ' You must provide at least 1 file name (VT) ' ; STOP 99
   CASE ( 1 ) ; lsepf = .false.; 
   CASE ( 2 ) ; lsepf = .true. ; cf_vfil = cf_vtfil ; cf_sfil = cf_tfil
   CASE ( 3 ) ; lsepf = .true. ; cf_vfil = cf_vtfil 
@@ -186,7 +186,7 @@ PROGRAM cdfmhst
      lchk = lchk .OR. chkfile( cf_sfil)
   ENDIF
 
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   ! check for sub basin file and set appropriate variables
   IF ( .NOT. chkfile(cn_fbasins ) ) THEN

--- a/src/cdfmht_gsop.f90
+++ b/src/cdfmht_gsop.f90
@@ -91,7 +91,7 @@ PROGRAM cdfmht_gsop
      PRINT *,'      variables zobtmhta  : Barotropic component '
      PRINT *,'      variables zoshmhta  : Vertical shear geostrophic component '
      PRINT *,'      variables zoagmhta  : vertical shear ageostrophic component (Ekman + residu)'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cfilev)

--- a/src/cdfmkmask.f90
+++ b/src/cdfmkmask.f90
@@ -114,7 +114,7 @@ PROGRAM cdfmkmask
       PRINT *,'         variables : tmask, umask, vmask, fmask'
       PRINT *,'                fmask can differ from standard fmask because it does not'
       PRINT *,'                reflect the slip/noslip lateral condition.'
-      STOP
+      STOP 99
    ENDIF
 
    ijarg = 1
@@ -155,7 +155,7 @@ PROGRAM cdfmkmask
          !
       CASE DEFAULT
          PRINT *, 'ERROR : unknown option :', TRIM(cldum)
-         STOP
+         STOP 99
       END SELECT
    ENDDO
 
@@ -174,10 +174,10 @@ PROGRAM cdfmkmask
       cf_tfil = 'bathylevel.nc'
       cn_z    = 'z'
       lmbathy = .TRUE.
-      IF ( chkfile(cn_fzgr) ) STOP ! missing file
+      IF ( chkfile(cn_fzgr) ) STOP 99 ! missing file
    END IF
 
-   IF ( chkfile(cf_tfil) ) STOP ! missing file
+   IF ( chkfile(cf_tfil) ) STOP 99 ! missing file
 
    npiglo = getdim (cf_tfil,cn_x)
    npjglo = getdim (cf_tfil,cn_y)
@@ -261,7 +261,7 @@ PROGRAM cdfmkmask
    ENDIF
 
    IF ( lzoombat ) THEN
-      IF ( chkfile(cn_fzgr) ) STOP ! missing file
+      IF ( chkfile(cn_fzgr) ) STOP 99 ! missing file
       ALLOCATE ( rbat  (npiglo,npjglo) )
       rbat(:,:)= getvar(cn_fzgr, cn_hdepw,  1 ,npiglo, npjglo)
    END IF

--- a/src/cdfmltmask.f90
+++ b/src/cdfmltmask.f90
@@ -83,7 +83,7 @@ PROGRAM cdfmltmask
      PRINT *,'       the requested variable masked.'
      PRINT *,'       netcdf file : IN-file_masked unless specified with -o '
      PRINT *,'         variables : IN-var (same as input).'
-     STOP
+     STOP 99
   ENDIF
 
   zspv0 = 0.
@@ -116,7 +116,7 @@ PROGRAM cdfmltmask
     END SELECT
   ENDDO
 
-  IF ( chkfile (cf_in) .OR. chkfile(cf_msk) ) STOP ! missing files
+  IF ( chkfile (cf_in) .OR. chkfile(cf_msk) ) STOP 99 ! missing files
 
   ! append _masked to input file name and copy initial file to new file, which will be modified
   !  using dd more efficient than cp for big files
@@ -200,7 +200,7 @@ PROGRAM cdfmltmask
      cv_msk='polymask'
   CASE DEFAULT
      PRINT *, 'this type of variable is not known :', TRIM(cvartype)
-     STOP
+     STOP 99
   END SELECT
   ENDIF
 

--- a/src/cdfmoc.f90
+++ b/src/cdfmoc.f90
@@ -172,7 +172,7 @@ PROGRAM cdfmoc
      PRINT *,'       traditionally.'
      PRINT *,'       Additional variables are also computed following CLIVAR-GODAE '
      PRINT *,'       reanalysis intercomparison project recommendations. '
-     STOP
+     STOP 99
   ENDIF
 
   cglobal = 'Partial step computation'
@@ -198,7 +198,7 @@ PROGRAM cdfmoc
         CASE ( 4 ) ; cf_ufil = cldum
         CASE DEFAULT
            PRINT*, 'ERROR : Too many arguments ...'
-           STOP
+           STOP 99
         END SELECT
      END SELECT
   END DO
@@ -208,12 +208,12 @@ PROGRAM cdfmoc
   lchk = lchk .OR. chkfile ( cn_fmsk )
   lchk = lchk .OR. chkfile ( cf_vfil )
   IF ( ldec ) lchk = lchk .OR. chkfile ( TRIM(cf_tfil) ) 
-  IF ( lchk ) STOP  ! missing file(s)
+  IF ( lchk ) STOP 99 ! missing file(s)
 
   IF ( lrap ) THEN 
      ! all the work will be done in a separated routine for RAPID-MOCHA section
      CALL rapid_amoc 
-     STOP  ! program stops here in this case
+     STOP 99 ! program stops here in this case
   ENDIF
 
   npiglo = getdim (cf_vfil,cn_x)

--- a/src/cdfmocsig.f90
+++ b/src/cdfmocsig.f90
@@ -200,7 +200,8 @@ PROGRAM cdfmocsig
              CASE DEFAULT                 ; READ(cldum,*) pref
              END SELECT
         CASE DEFAULT
-           STOP 'ERROR : Too many arguments ...'
+           PRINT *, 'ERROR : Too many arguments ...'
+           STOP 99
         END SELECT
      END SELECT
   END DO
@@ -211,7 +212,7 @@ PROGRAM cdfmocsig
   lchk = lchk .OR. chkfile ( cn_fmsk )
   lchk = lchk .OR. chkfile ( cf_vfil )
   lchk = lchk .OR. chkfile ( cf_tfil )
-  IF ( lchk ) STOP  ! missing file(s)
+  IF ( lchk ) STOP 99  ! missing file(s)
 
   ! re-use lchk for binning control : TRUE if no particular binning specified
   lchk = lbin(1) .OR. lbin(2) .OR. lbin(3) 
@@ -270,7 +271,7 @@ PROGRAM cdfmocsig
           PRINT *,' This value of depth_ref (',pref,') is not implemented as standard'
           PRINT *,' You must use the -sigmin, -sigstp and -nbins options to precise'
           PRINT *,' the density bining you want to use.'
-          STOP
+          STOP 99
        END SELECT
      ENDIF
   ENDIF

--- a/src/cdfmocsig.f90
+++ b/src/cdfmocsig.f90
@@ -158,7 +158,7 @@ PROGRAM cdfmocsig
      PRINT *,'       is used and only ',TRIM( cn_zomsfglo),' is produced.'
      PRINT *,'       If option -isodep is used, each MOC variable is complemented by a iso'
      PRINT *,'       variable, giving the zonal mean of ispycnal depth (e.g.',TRIM(cn_zoisoglo),').'
-     STOP
+     STOP 99
   ENDIF
 
   cglobal = 'Partial step computation'

--- a/src/cdfmoy.f90
+++ b/src/cdfmoy.f90
@@ -163,7 +163,7 @@ PROGRAM cdfmoy
      PRINT *,'     SEE ALSO :'
      PRINT *,'       cdfmoy_weighted, cdfstdev'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
 
@@ -202,7 +202,7 @@ PROGRAM cdfmoy
   IF ( lzermean ) THEN
     lchk = lchk .OR. chkfile ( cn_fhgr )
     lchk = lchk .OR. chkfile ( cn_fmsk )
-    IF ( lchk ) STOP ! missing files
+    IF ( lchk ) STOP 99 ! missing files
   ENDIF
 
   ! Initialisation from  1rst file (all file are assume to have the same geometry)
@@ -210,7 +210,7 @@ PROGRAM cdfmoy
   ! loop for files
 
   cf_in = cf_list(1)
-  IF ( chkfile (cf_in) ) STOP ! missing file
+  IF ( chkfile (cf_in) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_in, cn_x)
   npjglo = getdim (cf_in, cn_y)
@@ -412,7 +412,7 @@ PROGRAM cdfmoy
            DO jfil = 1, nfil
               cf_in = cf_list(jfil)
               IF ( jk == 1 ) THEN
-                  IF ( chkfile (cf_in) ) STOP ! missing file
+                  IF ( chkfile (cf_in) ) STOP 99 ! missing file
                   iwght=iwght+MAX(1,INT(getatt( cf_in, cv_nam(jvar), 'iweight')))
               ENDIF
 

--- a/src/cdfmoy_freq.f90
+++ b/src/cdfmoy_freq.f90
@@ -109,7 +109,7 @@ PROGRAM cdfmoy_freq
      PRINT *,'     SEE ALSO :'
      PRINT *,'      cdfmoy, cdfmoy_weighted'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   ! parse command line
@@ -129,7 +129,7 @@ PROGRAM cdfmoy_freq
      END SELECT
   END DO
 
-  IF ( chkfile ( cf_in ) ) STOP ! missing file
+  IF ( chkfile ( cf_in ) ) STOP 99 ! missing file
 
   ! parse the cfreqo to determine the output frequency. 
   ! Allowed syntax is nf<cfr_id> where nf is an integer >0, <cfr_id> is h, d, mo or y
@@ -150,12 +150,12 @@ PROGRAM cdfmoy_freq
   CASE ( 'd' ) 
      IF ( nf /= 1 .AND. nf/=5 ) THEN
         PRINT *, ' +++ ERROR : only 1d or 5d are acceptable !'
-        STOP
+        STOP 99
      ENDIF
   CASE ( 'y' )
      IF ( nf > 1 ) THEN
         PRINT *, ' +++ ERROR : Cannot have output freq > 1 y !'
-        STOP
+        STOP 99
      ENDIF
   END SELECT
 
@@ -189,7 +189,7 @@ PROGRAM cdfmoy_freq
      nhyr = ndyr*24 ! number of hours per leap year
      IF ( MOD( nhyr, npt ) /= 0 ) THEN
         PRINT *," +++ ERROR : npt do not fit in 365 nor 366 days "
-        STOP
+        STOP 99
      ELSE
         lleap=.TRUE.
      ENDIF
@@ -274,7 +274,7 @@ PROGRAM cdfmoy_freq
      PRINT *, ' +++ ERROR : Input and output frequency incompatible.'
      PRINT *, '         Input  : ',  nhfri,' hours '
      PRINT *, '         Output : ',  nf,' hours '
-     STOP
+     STOP 99
   ENDIF
 
   ALLOCATE( dtab(npiglo,npjglo), v2d(npiglo,npjglo) )

--- a/src/cdfmoy_weighted.f90
+++ b/src/cdfmoy_weighted.f90
@@ -96,7 +96,7 @@
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'       variables : same as in the input files'
-     STOP
+     STOP 99
   ENDIF
 
   ! scan command line and check if files exist
@@ -113,7 +113,7 @@
      CASE DEFAULT
         ixtra = ixtra + 1
         cf_in = cldum
-        IF ( chkfile (cldum ) ) STOP ! missing file
+        IF ( chkfile (cldum ) ) STOP 99 ! missing file
      END SELECT
   ENDDO
 
@@ -121,7 +121,7 @@
   IF ( lold5d .OR. lmonth ) THEN
      IF ( ixtra /= 12 ) THEN 
         PRINT *,' +++ ERROR : exactly 12 monthly files are required for -old5d/-month options.'
-        STOP
+        STOP 99
      ENDIF
   ENDIF
 

--- a/src/cdfmoyt.f90
+++ b/src/cdfmoyt.f90
@@ -109,7 +109,7 @@ PROGRAM cdfmoyt
      PRINT *,'       netcdf file : ', TRIM(cf_out),' and ',TRIM(cf_out2)
      PRINT *,'       variables : are the same than in the input files. For squared averages' 
      PRINT *,'       _sqd is append to the original variable name.'
-     STOP
+     STOP 99
   ENDIF
 
   ALLOCATE ( cf_list(narg) )
@@ -130,7 +130,7 @@ PROGRAM cdfmoyt
   ! time counter can be different for each file in the list. It is read in the
   ! loop for files
 
-  IF ( chkfile (cf_list(1)) ) STOP ! missing file
+  IF ( chkfile (cf_list(1)) ) STOP 99 ! missing file
 
   cf_in  = cf_list(1)
   npiglo = getdim (cf_in,cn_x)
@@ -158,14 +158,14 @@ PROGRAM cdfmoyt
   ! check that all files have the same number of time frames
   ierr = 0
   DO jfil = 1, nfil
-     IF (  chkfile (cf_list(jfil)      ) ) STOP ! missing file
+     IF (  chkfile (cf_list(jfil)      ) ) STOP 99 ! missing file
      inpt = getdim (cf_list(jfil), cn_t)
      IF ( inpt /= npt ) THEN
         PRINT *, 'File ',TRIM(cf_list(jfil) ),' has ',inpt,' time frames instead of ', npt
         ierr = ierr + 1
      ENDIF
   ENDDO
-  IF ( ierr /= 0 ) STOP ! frame numbers mismatch
+  IF ( ierr /= 0 ) STOP 99 ! frame numbers mismatch
 
   PRINT *, 'npiglo = ', npiglo
   PRINT *, 'npjglo = ', npjglo

--- a/src/cdfmoyuvwt.f90
+++ b/src/cdfmoyuvwt.f90
@@ -98,7 +98,7 @@ PROGRAM cdfmoyuvwt
      PRINT *,'     SEE ALSO :'
      PRINT *,'      cdfbti, cdfbci and cdfnrjcomp' 
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   iimin=0 ; ijmin=0
@@ -132,7 +132,7 @@ PROGRAM cdfmoyuvwt
      WRITE(cf_ufil,'(a,"_",a,"_gridU.nc")') TRIM(config),TRIM(ctag)
      IF ( chkfile (cf_ufil ) ) THEN 
         WRITE(cf_ufil,'(a,"_",a,"_grid_U.nc")') TRIM(config),TRIM(ctag)
-        IF ( chkfile (cf_ufil ) ) STOP ! missing gridU or grid_U file
+        IF ( chkfile (cf_ufil ) ) STOP 99 ! missing gridU or grid_U file
         llnam_nemo=.TRUE. ! assume all files are nemo style ...
      ENDIF
 
@@ -140,21 +140,21 @@ PROGRAM cdfmoyuvwt
      WRITE(cf_vfil,'(a,"_",a,"_gridV.nc")') TRIM(config),TRIM(ctag)
      IF ( chkfile (cf_vfil ) ) THEN 
         WRITE(cf_vfil,'(a,"_",a,"_grid_V.nc")') TRIM(config),TRIM(ctag)
-        IF ( chkfile (cf_vfil ) ) STOP ! missing gridV or grid_V file
+        IF ( chkfile (cf_vfil ) ) STOP 99 ! missing gridV or grid_V file
      ENDIF
 
      ! check W-file
      WRITE(cf_wfil,'(a,"_",a,"_gridW.nc")') TRIM(config),TRIM(ctag)
      IF ( chkfile (cf_wfil ) ) THEN 
         WRITE(cf_wfil,'(a,"_",a,"_grid_W.nc")') TRIM(config),TRIM(ctag)
-        IF ( chkfile (cf_wfil ) ) STOP ! missing gridW or grid_W file
+        IF ( chkfile (cf_wfil ) ) STOP 99 ! missing gridW or grid_W file
      ENDIF
 
      ! check T-file
      WRITE(cf_tfil,'(a,"_",a,"_gridT.nc")') TRIM(config),TRIM(ctag)
      IF ( chkfile (cf_tfil ) ) THEN 
         WRITE(cf_tfil,'(a,"_",a,"_grid_T.nc")') TRIM(config),TRIM(ctag)
-        IF ( chkfile (cf_tfil ) ) STOP ! missing gridT or grid_T file
+        IF ( chkfile (cf_tfil ) ) STOP 99 ! missing gridT or grid_T file
      ENDIF
   END DO
 

--- a/src/cdfmppini.f90
+++ b/src/cdfmppini.f90
@@ -76,7 +76,7 @@ PROGRAM cdfmppini
      PRINT *,'     OUTPUT : '
      PRINT *,'       - Standard output'
      PRINT *,'       - ASCII file ', TRIM(cf_out)
-     STOP
+     STOP 99
   ENDIF
   
   cf_msk = cn_fmsk ; cv_in='tmask'
@@ -94,12 +94,12 @@ PROGRAM cdfmppini
         SELECT CASE ( ireq )
         CASE ( 1 ) ; READ(cldum,*) jpni
         CASE ( 2 ) ; READ(cldum,*) jpnj
-        CASE DEFAULT ; PRINT *,' Too many arguments.'; STOP
+        CASE DEFAULT ; PRINT *,' Too many arguments.'; STOP 99
         END SELECT
      END SELECT
   END DO
 
-  IF ( chkfile (cf_msk ))  STOP ! missing file
+  IF ( chkfile (cf_msk ))  STOP 99 ! missing file
   
   jpiglo = getdim (cf_msk,cn_x)
   jpjglo = getdim (cf_msk,cn_y)

--- a/src/cdfmsk.f90
+++ b/src/cdfmsk.f90
@@ -45,16 +45,16 @@ PROGRAM cdfmsk
      PRINT *,'      '
      PRINT *,'     OUTPUT : '
      PRINT *,'       Standard output'
-     STOP
+     STOP 99
   ENDIF
   IF ( narg == 0 ) THEN
      PRINT *,' Usage : cdfmsk  maskfile '
-     STOP
+     STOP 99
   ENDIF
   
   CALL getarg (1, cf_msk)
 
-  IF ( chkfile(cf_msk) ) STOP ! missing file
+  IF ( chkfile(cf_msk) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_msk, cn_x)
   npjglo = getdim (cf_msk, cn_y)

--- a/src/cdfmxl.f90
+++ b/src/cdfmxl.f90
@@ -127,7 +127,7 @@ PROGRAM cdfmxl
      PRINT *,'                     somxlt05z10 = mld on temperature criterium -0.5 ref. 10m'
      PRINT *,'                     somxl030z10 = mld on density criterium 0.03 ref. 10m'
      PRINT *,'                     somxl125z10 = mld on density criterium 0.125 ref. 10m'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1 ; ixtra = 0
@@ -143,12 +143,12 @@ PROGRAM cdfmxl
       CASE ( 2 ) ; cf_sfil = cldum                      ! second free name ( if any) is a gridS file name
       CASE DEFAULT 
         PRINT *, ' +++ ERROR : Too many files in input !'
-        STOP
+        STOP 99
       END SELECT
     END SELECT
   ENDDO
 
-  IF ( chkfile(cf_tfil) .OR. chkfile(cn_fzgr) .OR. chkfile(cf_sfil)  ) STOP ! missing file
+  IF ( chkfile(cf_tfil) .OR. chkfile(cn_fzgr) .OR. chkfile(cf_sfil)  ) STOP 99 ! missing file
 
   ! read dimensions 
   npiglo = getdim (cf_tfil,cn_x)

--- a/src/cdfmxlhcsc.f90
+++ b/src/cdfmxlhcsc.f90
@@ -111,7 +111,7 @@ PROGRAM cdfmxlhcsc
      PRINT *,'     SEE ALSO :'
      PRINT *,'       cdfmxl, cdfmxlheatc and  cdfmxlsaltc.'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_tfil  )
@@ -123,7 +123,7 @@ PROGRAM cdfmxlhcsc
   lchk = chkfile (cn_fzgr) .OR. lchk
   lchk = chkfile (cn_fmsk) .OR. lchk
   lchk = chkfile (cf_tfil) .OR. lchk
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   ! read dimensions 
   npiglo = getdim (cf_tfil, cn_x)
@@ -145,7 +145,7 @@ PROGRAM cdfmxlhcsc
      !
   CASE DEFAULT
      PRINT *,TRIM(criteria),' : criteria not understood'
-     STOP
+     STOP 99
   END SELECT
 
   stypvar(1)%cname       = TRIM(cldum)
@@ -236,7 +236,7 @@ PROGRAM cdfmxlhcsc
         ENDDO
         !
      CASE DEFAULT
-        PRINT *,' ERROR: Criterium on ', TRIM(criteria),' not suported' ; STOP
+        PRINT *,' ERROR: Criterium on ', TRIM(criteria),' not suported' ; STOP 99
         !
      END SELECT
 

--- a/src/cdfmxlheatc.f90
+++ b/src/cdfmxlheatc.f90
@@ -81,7 +81,7 @@ PROGRAM cdfmxlheatc
      PRINT *,'     SEE ALSO :'
      PRINT *,'       cdfmxl, cdfmxlhcsc and  cdfmxlsaltc.'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1
@@ -92,14 +92,14 @@ PROGRAM cdfmxlheatc
     SELECT CASE ( cldum )
     CASE ( '-full'    ) ; lfull = .true.
     CASE ( '-o' )     ; CALL getarg (ijarg, cf_out ) ; ijarg = ijarg + 1
-    CASE DEFAULT  ; PRINT *, TRIM(cldum),' : unknown option' ; STOP
+    CASE DEFAULT  ; PRINT *, TRIM(cldum),' : unknown option' ; STOP 99
     END SELECT
   END DO
 
   lchk = chkfile (cn_fzgr)
   lchk = chkfile (cn_fmsk) .OR. lchk
   lchk = chkfile (cf_tfil) .OR. lchk
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   CALL SetGlobalAtt( cglobal) 
 

--- a/src/cdfmxlsaltc.f90
+++ b/src/cdfmxlsaltc.f90
@@ -81,7 +81,7 @@ PROGRAM cdfmxlsaltc
      PRINT *,'     SEE ALSO :'
      PRINT *,'       cdfmxl, cdfmxlhcsc, cdfmxlheatc ' 
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1 ; ireq = 0
@@ -105,7 +105,7 @@ PROGRAM cdfmxlsaltc
   lchk = chkfile (cn_fzgr)
   lchk = chkfile (cn_fmsk) .OR. lchk
   lchk = chkfile (cf_tfil  ) .OR. lchk
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   CALL SetGlobalAtt( cglobal )
 

--- a/src/cdfnamelist.f90
+++ b/src/cdfnamelist.f90
@@ -50,7 +50,7 @@ PROGRAM cdfnamelist
      PRINT *,'     OUTPUT : '
      PRINT *,'       with option -p, print a template namelist : PrintCdfNames.namlist'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1

--- a/src/cdfnan.f90
+++ b/src/cdfnan.f90
@@ -65,7 +65,7 @@ PROGRAM cdfnan
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : input file is rewritten without NaN.' 
      PRINT *,'         variables : same name as input.' 
-     STOP
+     STOP 99
   ENDIF
 
   rabsmax=huge(0.0)
@@ -83,7 +83,7 @@ PROGRAM cdfnan
         cf_inout=TRIM(cldum)
      END SELECT
   END DO
-  IF ( chkfile (cf_inout) )  STOP ! missing file
+  IF ( chkfile (cf_inout) )  STOP 99 ! missing file
 
   npiglo = getdim (cf_inout, cn_x              )
   npjglo = getdim (cf_inout, cn_y              )

--- a/src/cdfnorth_unfold.f90
+++ b/src/cdfnorth_unfold.f90
@@ -83,7 +83,7 @@ PROGRAM cdfnorth_unfold
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : same name and units than in the input file.'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_in )
@@ -92,7 +92,7 @@ PROGRAM cdfnorth_unfold
   CALL getarg (4, cpivot) 
   CALL getarg (5, ctype )
   
-  IF ( chkfile(cf_in) ) STOP ! missing file
+  IF ( chkfile(cf_in) ) STOP 99 ! missing file
 
   WRITE(cglobal,9000) 'cdfnorth_unfold ',TRIM(cf_in), ijatl, ijpacif, TRIM(cpivot), TRIM(ctype)
 9000 FORMAT(a,a,2i5,a,1x,a)
@@ -209,7 +209,7 @@ CONTAINS
     !!----------------------------------------------------------------------
 
     IF ( ldchk ) THEN
-      PRINT *,' Full check not written yet ' ; STOP
+      PRINT *,' Full check not written yet ' ; STOP 99
     ELSE
     SELECT CASE ( cdpivot)
     CASE ( 'T','t')
@@ -225,7 +225,7 @@ CONTAINS
              IF ( ABS(zrat) /= 1. ) THEN
                 PRINT *, 'INCOHERENT value in T point ', TRIM(cv_names(jvar)), zrat
                 ierr = closeout(ncout)
-                STOP
+                STOP 99
              ELSE
                 chkisig = zrat
              ENDIF
@@ -240,7 +240,7 @@ CONTAINS
           IF ( ABS(zrat) /= 1. ) THEN
              PRINT *, 'INCOHERENT value in U point ', TRIM(cv_names(jvar)), zrat
              ierr = closeout(ncout)
-             STOP
+             STOP 99
           ELSE
              chkisig=zrat
           ENDIF
@@ -254,13 +254,13 @@ CONTAINS
           IF ( ABS(zrat) /= 1. ) THEN
              PRINT *, 'INCOHERENT value in V point ', TRIM(cv_names(jvar)), zrat
              ierr = closeout(ncout)
-             STOP
+             STOP 99
           ELSE
              chkisig=zrat
           ENDIF
        END SELECT
     CASE ( 'F','f')
-       PRINT *, 'F pivot not done yet ' ; STOP
+       PRINT *, 'F pivot not done yet ' ; STOP 99
     END SELECT
     ENDIF
 
@@ -324,7 +324,7 @@ CONTAINS
           ENDDO
        END SELECT
     CASE ('F','f')   ! pivot
-       PRINT * , ' Not yet done for F pivot ' ; STOP
+       PRINT * , ' Not yet done for F pivot ' ; STOP 99
     END SELECT
 
   END SUBROUTINE unfold

--- a/src/cdfnrjcomp.f90
+++ b/src/cdfnrjcomp.f90
@@ -65,12 +65,12 @@ PROGRAM cdfnrjcomp
      PRINT *,'                     anotsqrt : mean squared temperature anomaly'
      PRINT *,'                     anousqrt : mean squared zonal velocity anomaly'
      PRINT *,'                     anovsqrt : mean squared meridional velocity anomaly'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg(1, cf_in)
 
-  IF ( chkfile(cf_in) ) STOP ! missing file
+  IF ( chkfile(cf_in) ) STOP 99 ! missing file
 
   npiglo = getdim(cf_in,cn_x)
   npjglo = getdim(cf_in,cn_y)

--- a/src/cdfokubo-w.f90
+++ b/src/cdfokubo-w.f90
@@ -73,7 +73,7 @@
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : sokubow (s^-2)'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg(1, cf_ufil)
@@ -86,7 +86,7 @@
   lchk = chkfile(cn_fmsk ) .OR. lchk
   lchk = chkfile(cf_ufil ) .OR. lchk
   lchk = chkfile(cf_vfil ) .OR. lchk
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   ! define new variables for output
   stypvar(1)%cname             = 'sokubow'
@@ -115,7 +115,7 @@
   !test if lev exists
   IF ( (npk==0) .AND. (ilev > 0) ) THEN
      PRINT *, 'Problem : npk = 0 and lev > 0 STOP'
-     STOP
+     STOP 99
   END IF
 
   ! if forcing field 

--- a/src/cdfovide.f90
+++ b/src/cdfovide.f90
@@ -105,7 +105,7 @@ PROGRAM cdfovide
      PRINT *,'usage : cdfovide gridTfile gridUfile gridVfile '
      PRINT *,'     Files ',TRIM(cn_fhgr),' and ',TRIM(cn_fzgr),' must be in te current directory '
      PRINT *,'     Output on netcdf file ',TRIM(cfileoutnc)
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cfilet)
@@ -117,7 +117,7 @@ PROGRAM cdfovide
   lchk = chkfile(cfilet ) .OR. lchk
   lchk = chkfile(cfileu ) .OR. lchk
   lchk = chkfile(cfilev ) .OR. lchk
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   ! R. Dussin : Location of leg points that define the 3 legs of OVIDE section
   !rlonsta(1) = -43.00 ; rlatsta(1) = 60.60    ! Greenland
@@ -217,7 +217,10 @@ PROGRAM cdfovide
         PRINT 9000, 'Long= ',glamfound,' Lat = ',gphi(iloc,jloc)&
              &               , iloc, jloc 
         PRINT *,' Algorithme ne converge pas ', rdis 
-        IF ( niter >=  1 ) STOP ' pas de convergence apres iteration'
+        IF ( niter >=  1 ) THEN
+           PRINT *, ' pas de convergence apres iteration'
+           STOP 99
+        ENDIF
         lagain = .TRUE.
         jloc = npjglo
         niter = niter +1
@@ -252,7 +255,10 @@ PROGRAM cdfovide
         PRINT 9000, 'Long= ',glamfound,' Lat = ',gphi(iloc,jloc) &
              &               , iloc, jloc
         PRINT *,' Algorithme ne converge pas ', rdis
-        IF ( niter >= 1 ) STOP ' pas de convergence avres iteration'
+        IF ( niter >= 1 ) THEN
+           PRINT *, ' pas de convergence avres iteration'
+           STOP 99
+        ENDIF
         lagain = .TRUE.
         jloc  = npjglo
         niter = niter +1
@@ -334,7 +340,10 @@ PROGRAM cdfovide
         ! ... compute the nearest j point on the line crossing at i
         DO i=i0,i1
            n=n+1
-           IF (n > jpseg) STOP 'n > jpseg !'
+           IF (n > jpseg) THEN
+              PRINT *, 'n > jpseg !'
+              STOP 99
+           ENDIF
            j=NINT(aj*i + bj )
            yypt(n) = CMPLX(i,j)
         END DO
@@ -359,7 +368,10 @@ PROGRAM cdfovide
         ! ... compute the nearest i point on the line crossing at j
         DO j=j0,j1
            n=n+1
-           IF (n > jpseg) STOP 'n>jpseg !'
+           IF (n > jpseg) THEN
+              PRINT *, 'n>jpseg !'
+              STOP 99
+           ENDIF
            i=NINT(ai*j + bi)
            yypt(n) = CMPLX(i,j)
         END DO
@@ -379,12 +391,18 @@ PROGRAM cdfovide
         IF ( d > 1 ) THEN
            CALL interm_pt(yypt,kk,ai,bi,aj,bj,yypti)
            nn=nn+1
-           IF (nn > jpseg) STOP 'nn>jpseg !'
+           IF (nn > jpseg) THEN
+              PRINT *, 'nn>jpseg !'
+              STOP 99
+           ENDIF
            rxx(nn)=REAL(yypti)
            ryy(nn)=IMAG(yypti)
         END IF
         nn=nn+1
-        IF (nn > jpseg) STOP 'nn>jpseg !'
+        IF (nn > jpseg) THEN
+           PRINT *, 'nn>jpseg !'
+           STOP 99
+        ENDIF
         rxx(nn)=REAL(yypt(kk))
         ryy(nn)=IMAG(yypt(kk))
      END DO

--- a/src/cdfpdf.f90
+++ b/src/cdfpdf.f90
@@ -91,7 +91,7 @@ PROGRAM cdfpdf
      PRINT *,'              netdf variable is <IN-var>_pdf'
      PRINT *,'      '
      PRINT *,'     SEE ALSO : '
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1
@@ -120,7 +120,7 @@ PROGRAM cdfpdf
      END SELECT
   ENDDO
 
-  IF (  chkfile ( cf_ifil) ) STOP  ! some compulsory files are missing
+  IF (  chkfile ( cf_ifil) ) STOP 99 ! some compulsory files are missing
 
   ! set domain size from input ile
   npiglo = getdim (cf_ifil,cn_x)

--- a/src/cdfpendep.f90
+++ b/src/cdfpendep.f90
@@ -74,21 +74,21 @@ PROGRAM cdfpendep
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : pendep (m)'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1
   CALL getarg (ijarg, cf_trcfil) ; ijarg = ijarg + 1 
   CALL getarg (ijarg, cf_inv   ) ; ijarg = ijarg + 1
 
-  IF ( chkfile(cf_trcfil) .OR. chkfile(cf_inv) ) STOP ! missing file
+  IF ( chkfile(cf_trcfil) .OR. chkfile(cf_inv) ) STOP 99 ! missing file
 
   DO WHILE ( ijarg <= narg)
      CALL getarg(ijarg, cldum ) ; ijarg = ijarg + 1 
      SELECT CASE ( cldum )
      CASE ('-inv') ;  CALL getarg(ijarg, cv_inv) ; ijarg=ijarg+1
      CASE ('-trc') ;  CALL getarg(ijarg, cv_trc) ; ijarg=ijarg+1
-     CASE DEFAULT  ; PRINT *, 'option ', TRIM(cldum),' not understood' ; STOP
+     CASE DEFAULT  ; PRINT *, 'option ', TRIM(cldum),' not understood' ; STOP 99
      END SELECT
   END DO
 

--- a/src/cdfpolymask.f90
+++ b/src/cdfpolymask.f90
@@ -77,7 +77,7 @@ PROGRAM cdfpolymask
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : polymask'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1 
@@ -91,11 +91,11 @@ PROGRAM cdfpolymask
      CASE DEFAULT
         PRINT *,' unknown optional arugment (', TRIM(cldum),' )'
         PRINT *,' in actual version only -r -- for reverse -- is recognized '
-        STOP
+        STOP 99
      END SELECT
   END DO
 
-  IF ( chkfile(cf_poly) .OR. chkfile(cf_ref) ) STOP ! missing files
+  IF ( chkfile(cf_poly) .OR. chkfile(cf_ref) ) STOP 99 ! missing files
 
   npiglo = getdim (cf_ref, cn_x)
   npjglo = getdim (cf_ref, cn_y)

--- a/src/cdfprobe.f90
+++ b/src/cdfprobe.f90
@@ -46,7 +46,7 @@ PROGRAM cdfprobe
      PRINT *,'     OUTPUT : '
      PRINT *,'       2 columns ( time , value ) ASCII output on display'
      PRINT *,'       time are given in days since the begining of the run.'
-     STOP
+     STOP 99
   ENDIF
 
   ! Browse command line
@@ -55,7 +55,7 @@ PROGRAM cdfprobe
   CALL getarg(3, cldum ) ; READ(cldum,*) ijlook
   CALL getarg(4, cv_in ) 
 
-  IF ( chkfile(cf_in) ) STOP ! missing file
+  IF ( chkfile(cf_in) ) STOP 99 ! missing file
 
   IF ( narg == 5 ) THEN
      CALL getarg(5, cldum) ;  READ(cldum,*) ilevel

--- a/src/cdfprofile.f90
+++ b/src/cdfprofile.f90
@@ -77,7 +77,7 @@ PROGRAM cdfprofile
      PRINT *,'       netcdf file : ', TRIM(cf_out)
      PRINT *,'          variable : name given as argument.'
      PRINT *,'       Profile is also written on standard output.'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1
@@ -97,7 +97,7 @@ PROGRAM cdfprofile
    END SELECT
   ENDDO
       
-  IF ( chkfile(cf_in) ) STOP ! missing file
+  IF ( chkfile(cf_in) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_in, cn_x)
   npjglo = getdim (cf_in, cn_y)

--- a/src/cdfpsi.f90
+++ b/src/cdfpsi.f90
@@ -124,7 +124,7 @@ PROGRAM cdfpsi
      PRINT *,'                     ', TRIM(cv_outssh),' (m3/s ) : contribution of SSH'
      PRINT *,'                     ', TRIM(cv_outotal),' (m3/s ) : total BSF'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   CALL SetGlobalAtt (cglobal)
@@ -153,7 +153,7 @@ PROGRAM cdfpsi
         CASE ( 2 ) ; cf_vfil = cldum
         CASE ( 3 ) ; ll_v = .TRUE. ; ll_u = .FALSE.
         CASE DEFAULT
-           PRINT *, ' Too many arguments !' ; STOP
+           PRINT *, ' Too many arguments !' ; STOP 99
         END SELECT
      END SELECT
   ENDDO
@@ -165,7 +165,7 @@ PROGRAM cdfpsi
   lchk = lchk .OR. chkfile( cf_ufil )
   lchk = lchk .OR. chkfile( cf_vfil )
 
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   npiglo = getdim (cf_ufil, cn_x)
   npjglo = getdim (cf_ufil, cn_y)

--- a/src/cdfpsi_level.f90
+++ b/src/cdfpsi_level.f90
@@ -63,7 +63,7 @@ PROGRAM cdfpsi_level
      PRINT *,' Files mesh_hgr.nc, mesh_zgr.nc ,mask.nc must be in te current directory'
      PRINT *,' Output on psi_level.nc, variables sobarstf on f-points'
      PRINT *,' Default works well for a global ORCA grid. use V 3rdargument for North Atlantic'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cfileu  )

--- a/src/cdfpvor.f90
+++ b/src/cdfpvor.f90
@@ -125,7 +125,7 @@ PROGRAM cdfpvor
      PRINT *,'     SEE ALSO :'
      PRINT *,'       cdfcurl ( compute only the curl on 1 level)'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1  ; ireq = 0
@@ -144,7 +144,7 @@ PROGRAM cdfpvor
         CASE ( 2 ) ; cf_ufil = cldum
         CASE ( 3 ) ; cf_vfil = cldum
         CASE DEFAULT
-           PRINT *,' Too many arguments '; STOP
+           PRINT *,' Too many arguments '; STOP 99
         END SELECT
      END SELECT
   END DO
@@ -156,7 +156,7 @@ PROGRAM cdfpvor
      lchk = lchk .OR. chkfile( cf_ufil)
      lchk = lchk .OR. chkfile( cf_vfil)
   ENDIF
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   npiglo = getdim (cf_tfil, cn_x)
   npjglo = getdim (cf_tfil, cn_y)

--- a/src/cdfrhoproj.f90
+++ b/src/cdfrhoproj.f90
@@ -131,7 +131,7 @@ PROGRAM cdfrhoproj
      PRINT *,'     SEE ALSO :'
      PRINT *,'       replace cdfisopycdep when using -isodep option,  cdfmocsig'
      PRINT *,'       '
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1 ; ireq=0 ; nfilin=0
@@ -165,7 +165,7 @@ PROGRAM cdfrhoproj
 
   lchk = chkfile(cf_rhofil)
   IF ( .NOT. lsingle ) lchk = lchk .OR. chkfile(cf_rholev)
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   IF ( .NOT.  lsingle ) THEN
      OPEN(numlev,FILE=cf_rholev)
@@ -278,7 +278,8 @@ PROGRAM cdfrhoproj
      END DO
      ierr = putvar1d(ncout, tim, 1, 'T')
      ierr = closeout(ncout    )
-     STOP ' -isodep option in use: only compute depth of isopycnal surfaces.'
+     PRINT *, ' -isodep option in use: only compute depth of isopycnal surfaces.'
+     STOP 99
   ENDIF
 
   !! ** Loop on the scalar files to project on choosen isopycnics surfaces
@@ -292,7 +293,8 @@ PROGRAM cdfrhoproj
      IF (npt /= 1 ) THEN
         PRINT *,' This program has to be modified for multiple'
         PRINT *,' time frames.'
-        STOP ' Error : npt # 1'
+        PRINT *, ' Error : npt # 1'
+        STOP 99
      ENDIF
      tim(:)=getvar1d(cf_dta, cn_vtimec, 1)
  
@@ -439,7 +441,7 @@ PROGRAM cdfrhoproj
          sigstp = 0.
       ELSE
          PRINT *,' Error in -s0 option : either -s0 val  or -s0 sigmin,sigstp,nbins'
-         STOP
+         STOP 99
       ENDIF
 
       ALLOCATE ( zi(npsig) )

--- a/src/cdfrichardson.f90
+++ b/src/cdfrichardson.f90
@@ -86,7 +86,7 @@ PROGRAM cdfrichardson
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'       variables : ', TRIM(cv_ric)
-     STOP
+     STOP 99
   ENDIF
 
   cglobal = 'Partial step computation'
@@ -101,7 +101,7 @@ PROGRAM cdfrichardson
      SELECT CASE (cldum)
      CASE ('W','w') ; l_w   = .TRUE.
      CASE ('-full') ; lfull = .TRUE. ; cglobal = 'full step computation'
-     CASE DEFAULT   ; PRINT *,' Option not understood :', TRIM(cldum) ; STOP
+     CASE DEFAULT   ; PRINT *,' Option not understood :', TRIM(cldum) ; STOP 99
      END SELECT
   END DO
 
@@ -109,7 +109,7 @@ PROGRAM cdfrichardson
   lchk = lchk .OR. chkfile (cf_tfil  )
   lchk = lchk .OR. chkfile (cf_ufil  )
   lchk = lchk .OR. chkfile (cf_vfil  )
-  IF ( lchk  ) STOP  ! missing files 
+  IF ( lchk  ) STOP 99 ! missing files 
 
   npiglo = getdim (cf_tfil, cn_x)
   npjglo = getdim (cf_tfil, cn_y)

--- a/src/cdfrmsssh.f90
+++ b/src/cdfrmsssh.f90
@@ -80,7 +80,7 @@ PROGRAM cdfrmsssh
      PRINT *,'      '
      PRINT *,'     SEA ALSO :'
      PRINT *,'       cdfstd, cdfstdevw, cdfstdevts.'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1  ; ixtra = 0
@@ -95,7 +95,7 @@ PROGRAM cdfrmsssh
         CASE ( 1 ) ; cf_in  = cldum
         CASE ( 2 ) ; cf_in2 = cldum
         CASE DEFAULT
-           PRINT *, ' Too many variables ' ; STOP
+           PRINT *, ' Too many variables ' ; STOP 99
         END SELECT
      END SELECT
   ENDDO
@@ -103,7 +103,7 @@ PROGRAM cdfrmsssh
   ! check existence of files
   lchk = lchk .OR. chkfile(cf_in  )
   lchk = lchk .OR. chkfile(cf_in2 )
-  IF (lchk ) STOP ! missing file
+  IF (lchk ) STOP 99 ! missing file
 
   npiglo = getdim (cf_in, cn_x)
   npjglo = getdim (cf_in, cn_y)

--- a/src/cdfscale.f90
+++ b/src/cdfscale.f90
@@ -57,14 +57,14 @@ PROGRAM cdfscale
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : input file is rewritten ' 
      PRINT *,'         variables : same name as input.' 
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg(1, cf_inout) 
   CALL getarg(2, cv_inout) 
   CALL getarg(3, cldum)  ; READ(cldum,*) vscale
 
-  IF ( chkfile (cf_inout) )  STOP ! missing file
+  IF ( chkfile (cf_inout) )  STOP 99 ! missing file
 
   npiglo = getdim (cf_inout, cn_x              )
   npjglo = getdim (cf_inout, cn_y              )

--- a/src/cdfsections.f90
+++ b/src/cdfsections.f90
@@ -120,7 +120,7 @@ REAL*8,ALLOCATABLE,DIMENSION(:) :: d, X1
      PRINT *,' cdfsections U.nc V.nc T.nc 48.0 305.0 1 49.0 307.0 50.5 337.5 20'
      PRINT *,'Example for a section made of 2 linear segments : '
      PRINT *,' cdfsections U.nc V.nc T.nc 48.0 305.0 2 49.0 307.0 50.5 337.5 20 40.3 305.1 50'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, file_in_U )
@@ -136,7 +136,7 @@ REAL*8,ALLOCATABLE,DIMENSION(:) :: d, X1
     PRINT *, 'Usage : '
     PRINT *, ' cdfsections  Ufile Vfile Tfile larf lorf Nsec lat1 lon1 lat2 lon2 n1 ....'
     PRINT *, '-> please execute cdfsections without any arguments for more details.'
-    STOP
+    STOP 99
   endif
 
   ALLOCATE( lat(Nsec+1), lon(Nsec+1) )
@@ -154,7 +154,7 @@ REAL*8,ALLOCATABLE,DIMENSION(:) :: d, X1
   do i=1,Nsec+1
     if ( (lon(i).lt.0.0).or.(lonref.lt.0.0) ) then
       PRINT *, '**!/# ERROR : longitudes must be between 0 and 360'
-      STOP
+      STOP 99
     endif
   enddo
    
@@ -896,7 +896,7 @@ SUBROUTINE erreur(iret, lstop, chaine)
     WRITE(*,*) 'ERREUR: ', iret
     message=NF90_STRERROR(iret)
     WRITE(*,*) 'THIS MEANS :',TRIM(message)
-    IF ( lstop ) STOP
+    IF ( lstop ) STOP 99
   ENDIF
   !
 END SUBROUTINE erreur

--- a/src/cdfsig0.f90
+++ b/src/cdfsig0.f90
@@ -73,7 +73,7 @@ PROGRAM cdfsig0
      PRINT *,'      '
      PRINT *,'     SEE ALSO :'
      PRINT *,'       cdfsigi'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg=1
@@ -92,12 +92,12 @@ PROGRAM cdfsig0
          cf_tfil = cldum
       ELSE
          PRINT *,' option ',TRIM(cldum),' not understood'
-         STOP
+         STOP 99
       ENDIF
      END SELECT
   ENDDO
  
-  IF (chkfile(cf_tfil) ) STOP ! missing file
+  IF (chkfile(cf_tfil) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_tfil, cn_x)
   npjglo = getdim (cf_tfil, cn_y)

--- a/src/cdfsigi.f90
+++ b/src/cdfsigi.f90
@@ -68,13 +68,13 @@ PROGRAM cdfsigi
      PRINT *,'     SEE ALSO :'
      PRINT *,'      cdfsig0' 
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_tfil)
   CALL getarg (2, cldum) ; READ(cldum,*) ref_dep
 
-  IF ( chkfile(cf_tfil) ) STOP ! missing file
+  IF ( chkfile(cf_tfil) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_tfil, cn_x)
   npjglo = getdim (cf_tfil, cn_y)

--- a/src/cdfsiginsitu.f90
+++ b/src/cdfsiginsitu.f90
@@ -81,7 +81,7 @@ PROGRAM cdfsiginsitu
      PRINT *,'     SEE ALSO :'
      PRINT *,'      cdfsig0, cdfsigi '
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   ijarg=1
@@ -101,12 +101,12 @@ PROGRAM cdfsiginsitu
          cf_tfil = cldum
       ELSE
          PRINT *,' option ',TRIM(cldum),' not understood'
-         STOP
+         STOP 99
       ENDIF
      END SELECT
   ENDDO
 
-  IF ( chkfile(cf_tfil) ) STOP ! missing file
+  IF ( chkfile(cf_tfil) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_tfil,cn_x)
   npjglo = getdim (cf_tfil,cn_y)

--- a/src/cdfsigintegr.f90
+++ b/src/cdfsigintegr.f90
@@ -121,7 +121,7 @@ PROGRAM cdfsigintegr
      PRINT *,'     SEE ALSO :'
      PRINT *,'      cdfrhoproj, cdfsigtrp, cdfisopycdep'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1 ; ireq = 0 ; nfiles = 0
@@ -154,7 +154,7 @@ PROGRAM cdfsigintegr
   lchk = lchk .OR. chkfile (cn_fzgr   )
   lchk = lchk .OR. chkfile (cf_rholev )
   lchk = lchk .OR. chkfile (cf_rho    )
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   ! Read rho level between which the integral is being performed
   OPEN(numin,file=cf_rholev)
@@ -174,7 +174,7 @@ PROGRAM cdfsigintegr
   zspvalz=getspval(cf_rho, cn_vosigma0)
 
   CALL getarg(istrt_arg, cf_in)
-  IF ( chkfile ( cf_in ) ) STOP ! missing file
+  IF ( chkfile ( cf_in ) ) STOP 99 ! missing file
 
   nvars=getnvar(cf_in)
   ALLOCATE(cv_names(nvars), stypzvar(nvars))
@@ -284,7 +284,7 @@ PROGRAM cdfsigintegr
   DO jfich=1, nfiles
 
      CALL getarg(jfich+istrt_arg-1, cf_in)
-     IF ( chkfile (cf_in) ) STOP ! missing file
+     IF ( chkfile (cf_in) ) STOP 99 ! missing file
      PRINT *,'working with ', TRIM(cf_in)
 
      ! create output file

--- a/src/cdfsigintegr_bottom.f90
+++ b/src/cdfsigintegr_bottom.f90
@@ -125,7 +125,7 @@ PROGRAM cdfsigintegr_bottom
      PRINT *,'     SEE ALSO :'
      PRINT *,'      cdfrhoproj, cdfsigtrp, cdfisopycdep'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1 ; ireq = 0 ; nfiles = 0
@@ -159,7 +159,7 @@ PROGRAM cdfsigintegr_bottom
   lchk = lchk .OR. chkfile (cn_fhgr   )
   lchk = lchk .OR. chkfile (cf_rholev )
   lchk = lchk .OR. chkfile (cf_rho    )
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   ! Read rho level between which the integral is being performed
   OPEN(numin,file=cf_rholev)
@@ -179,7 +179,7 @@ PROGRAM cdfsigintegr_bottom
   zspvalz=getspval(cf_rho, cn_vosigma0)
 
   CALL getarg(istrt_arg, cf_in)
-  IF ( chkfile ( cf_in ) ) STOP ! missing file
+  IF ( chkfile ( cf_in ) ) STOP 99 ! missing file
 
   nvars=getnvar(cf_in)
   ALLOCATE(cv_names(nvars), stypzvar(nvars))
@@ -319,7 +319,7 @@ PROGRAM cdfsigintegr_bottom
   DO jfich=1, nfiles
 
      CALL getarg(jfich+istrt_arg-1, cf_in)
-     IF ( chkfile (cf_in) ) STOP ! missing file
+     IF ( chkfile (cf_in) ) STOP 99 ! missing file
      PRINT *,'working with ', TRIM(cf_in)
 
      ! create output file

--- a/src/cdfsigintegr_pedro.f90
+++ b/src/cdfsigintegr_pedro.f90
@@ -136,7 +136,7 @@ PROGRAM cdfsigintegr_pedro
      PRINT *,'     SEE ALSO :'
      PRINT *,'      cdfrhoproj, cdfsigtrp, cdfisopycdep'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
   pi=ACOS(-1.)
   !ijarg = 1 ; ireq = 0 ; nfiles = 0
@@ -158,7 +158,7 @@ PROGRAM cdfsigintegr_pedro
         CASE DEFAULT 
            !nfiles=nfiles+1
            !IF ( nfiles == 1 ) istrt_arg = ijarg - 1
-           PRINT *,' Too many arguments ' ; STOP
+           PRINT *,' Too many arguments ' ; STOP 99
         END SELECT
      END SELECT
   END DO
@@ -172,7 +172,7 @@ PROGRAM cdfsigintegr_pedro
   lchk = lchk .OR. chkfile (cf_rho    )
   lchk = lchk .OR. chkfile (cf_ufil   )
   lchk = lchk .OR. chkfile (cf_vfil   )
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   ! Read rho level between which the integral is being performed
   OPEN(numin,file=cf_rholev)
@@ -192,7 +192,7 @@ PROGRAM cdfsigintegr_pedro
   zspvalz=getspval(cf_rho, cn_vosigma0)
 
   !CALL getarg(istrt_arg, cf_ufil)
-  !IF ( chkfile ( cf_ufil ) ) STOP ! missing file
+  !IF ( chkfile ( cf_ufil ) ) STOP 99 ! missing file
 
   nvars=getnvar(cf_vfil)
   ALLOCATE(cv_names(nvars), stypzvar(nvars))
@@ -378,8 +378,8 @@ PROGRAM cdfsigintegr_pedro
   !DO jfich=1, nfiles
 
      !CALL getarg(jfich+istrt_arg-1, cf_ufil)
-     !IF ( chkfile (cf_ufil) ) STOP ! missing file
-     !IF ( chkfile (cf_vfil) ) STOP ! missing file
+     !IF ( chkfile (cf_ufil) ) STOP 99 ! missing file
+     !IF ( chkfile (cf_vfil) ) STOP 99 ! missing file
      PRINT *,'working with ', TRIM(cf_ufil)
      PRINT *,'working with ', TRIM(cf_vfil)
 

--- a/src/cdfsigntr.f90
+++ b/src/cdfsigntr.f90
@@ -60,11 +60,11 @@ PROGRAM cdfsigntr
      PRINT *,'      '
      PRINT *,'     SEE ALSO :'
      PRINT *,'       cdfsig0, cdfsigi, cdfsiginsitu'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_tfil)
-  IF (chkfile(cf_tfil) ) STOP ! missing file
+  IF (chkfile(cf_tfil) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_tfil, cn_x)
   npjglo = getdim (cf_tfil, cn_y)

--- a/src/cdfsigtrp.f90
+++ b/src/cdfsigtrp.f90
@@ -198,7 +198,7 @@ PROGRAM cdfsigtrp
       PRINT *,'     SEE ALSO :'
       PRINT *,'      cdfrhoproj, cdftransport, cdfsigintegr '
       PRINT *,'      '
-      STOP
+      STOP 99
    ENDIF
 
    ! browse command line
@@ -224,7 +224,7 @@ PROGRAM cdfsigtrp
          CASE ( 5 ) ; READ(cldum,*) dsigma_max
          CASE ( 6 ) ; READ(cldum,*) nbins
          CASE DEFAULT 
-            PRINT *,' Too many arguments ' ; STOP
+            PRINT *,' Too many arguments ' ; STOP 99
          END SELECT
       END SELECT
    END DO
@@ -236,7 +236,7 @@ PROGRAM cdfsigtrp
    lchk = lchk .OR. chkfile( cf_tfil    )
    lchk = lchk .OR. chkfile( cf_ufil    )
    lchk = lchk .OR. chkfile( cf_vfil    )
-   IF ( lchk ) STOP ! missing file
+   IF ( lchk ) STOP 99 ! missing file
    IF ( ltemp)  THEN  ! temperature decrease downward. Change sign and swap min/max
       refdep = -10. ! flag value
       dltsig     = dsigma_max  ! use dltsig as dummy variable for swapping

--- a/src/cdfsigtrp_broken.f90
+++ b/src/cdfsigtrp_broken.f90
@@ -198,7 +198,7 @@ PROGRAM cdfsigtrp_broken
      PRINT *,'     SEE ALSO :'
      PRINT *,'      cdfrhoproj, cdftransport, cdfsigintegr, cdfsigtrp, cdf_xtrac_brokenline '
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   ! browse command line
@@ -222,7 +222,7 @@ PROGRAM cdfsigtrp_broken
         CASE ( 3 ) ; READ(cldum,*) dsigma_max
         CASE ( 4 ) ; READ(cldum,*) nbins
         CASE DEFAULT 
-           PRINT *,' Too many arguments ' ; STOP
+           PRINT *,' Too many arguments ' ; STOP 99
         END SELECT
      END SELECT
   END DO
@@ -230,7 +230,7 @@ PROGRAM cdfsigtrp_broken
   lchk = lchk .OR. chkfile( cn_fzgr    )
   lchk = lchk .OR. chkfile( cf_section )
   lchk = lchk .OR. chkfile( cf_brfi    )
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
   IF ( ltemp)  THEN  ! temperature decrease downward. Change sign and swap min/max
      refdep = -10. ! flag value
      dltsig     = dsigma_max  ! use dltsig as dummy variable for swapping

--- a/src/cdfsigtrp_broken2.f90
+++ b/src/cdfsigtrp_broken2.f90
@@ -200,7 +200,7 @@ PROGRAM cdfsigtrp_broken
       PRINT *,'     SEE ALSO :'
       PRINT *,'      cdfrhoproj, cdftransport, cdfsigintegr '
       PRINT *,'      '
-      STOP
+      STOP 99
    ENDIF
 
    ! browse command line
@@ -226,7 +226,7 @@ PROGRAM cdfsigtrp_broken
          CASE ( 3 ) ; READ(cldum,*) dsigma_max
          CASE ( 4 ) ; READ(cldum,*) nbins
          CASE DEFAULT 
-            PRINT *,' Too many arguments ' ; STOP
+            PRINT *,' Too many arguments ' ; STOP 99
          END SELECT
       END SELECT
    END DO
@@ -238,7 +238,7 @@ PROGRAM cdfsigtrp_broken
    lchk = lchk .OR. chkfile( cf_tfil    )
    !lchk = lchk .OR. chkfile( cf_ufil    )
    !lchk = lchk .OR. chkfile( cf_vfil    )
-   IF ( lchk ) STOP ! missing file
+   IF ( lchk ) STOP 99 ! missing file
    IF ( ltemp)  THEN  ! temperature decrease downward. Change sign and swap min/max
       refdep = -10. ! flag value
       dltsig     = dsigma_max  ! use dltsig as dummy variable for swapping

--- a/src/cdfsmooth.f90
+++ b/src/cdfsmooth.f90
@@ -117,7 +117,7 @@ PROGRAM cdfsmooth
      PRINT *,'       of the filter type (1 letter) and of ncut.'
      PRINT *,'       netcdf file :   IN-file[LHSB]ncut'
      PRINT *,'         variables : same as input variables.'
-     STOP
+     STOP 99
   ENDIF
   !
   ijarg = 1
@@ -138,9 +138,12 @@ PROGRAM cdfsmooth
      END SELECT
   ENDDO
 
-  IF ( ncut == 0 ) STOP ' cdfsmooth : ncut = 0 --> nothing to do !'
+  IF ( ncut == 0 ) THEN
+     PRINT *, ' cdfsmooth : ncut = 0 --> nothing to do !'
+     STOP 99
+  ENDIF
 
-  IF ( chkfile(cf_in) ) STOP ! missing file
+  IF ( chkfile(cf_in) ) STOP 99 ! missing file
 
   !  remark: for a spatial filter, fn=dx/lambda where dx is spatial step, lamda is cutting wavelength
   fn    = 1./ncut
@@ -173,7 +176,7 @@ PROGRAM cdfsmooth
           PRINT *,' Working with Box filter'
         ENDIF
      CASE DEFAULT
-        PRINT *, TRIM(ctyp),' : undefined filter ' ; STOP
+        PRINT *, TRIM(ctyp),' : undefined filter ' ; STOP 99
      END SELECT
 
   CALL filterinit (nfilter, fn, nband)

--- a/src/cdfspeed.f90
+++ b/src/cdfspeed.f90
@@ -76,7 +76,7 @@ PROGRAM cdfspeed
      PRINT *,'    '
      PRINT *,'    OUTPUT :'
      PRINT *,'       Output on ',TRIM(cf_out),'  variable U '
-     STOP
+     STOP 99
   ENDIF
 
   nlev =0
@@ -92,7 +92,7 @@ PROGRAM cdfspeed
        END DO
      CASE ( '-t' ) 
        CALL getarg(ijarg, cf_tfil ) ; ijarg = ijarg + 1
-       IF ( chkfile (cf_tfil) ) STOP ! missing file
+       IF ( chkfile (cf_tfil) ) STOP 99 ! missing file
      CASE ( '-nc4' ) 
        lnc4=.true.
      CASE ( '-o' ) 
@@ -100,7 +100,7 @@ PROGRAM cdfspeed
      CASE DEFAULT
        cf_ufil = cldum
        CALL getarg(ijarg, cf_vfil ) ; ijarg = ijarg + 1
-       IF ( chkfile(cf_ufil) .OR. chkfile(cf_vfil) ) STOP ! missing file
+       IF ( chkfile(cf_ufil) .OR. chkfile(cf_vfil) ) STOP 99 ! missing file
        CALL getarg(ijarg, cv_u ) ; ijarg = ijarg + 1
        CALL getarg(ijarg, cv_v ) ; ijarg = ijarg + 1
      END SELECT 
@@ -121,7 +121,7 @@ PROGRAM cdfspeed
      IF ( TRIM(cf_tfil) == 'none' ) THEN
        PRINT *,'  ERROR: you must specify a griT file as fifth argument '
        PRINT *,'     This is for the proper header of output file '
-       STOP
+       STOP 99
      ENDIF
   END IF
 

--- a/src/cdfspice.f90
+++ b/src/cdfspice.f90
@@ -100,7 +100,7 @@ PROGRAM cdfspice
      PRINT *,'       Flament (2002) "A state variable for characterizing '
      PRINT *,'             water masses and their diffusive stability: spiciness."'
      PRINT *,'             Progress in Oceanography Volume 54, 2002, Pages 493-501.'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg=1
@@ -119,12 +119,12 @@ PROGRAM cdfspice
          cf_tfil = cldum
       ELSE
          PRINT *,' option ',TRIM(cldum),' not understood'
-         STOP
+         STOP 99
       ENDIF
      END SELECT
   ENDDO
 
-  IF ( chkfile(cf_tfil) ) STOP ! missing files
+  IF ( chkfile(cf_tfil) ) STOP 99 ! missing files
 
   npiglo = getdim (cf_tfil,cn_x)
   npjglo = getdim (cf_tfil,cn_y)

--- a/src/cdfsstconv.f90
+++ b/src/cdfsstconv.f90
@@ -82,7 +82,7 @@ PROGRAM cdfflxconv
      PRINT *,'    Output 6 cdf files : for emp, qnet, qsr, sst, taux, tauy with standard var name :'
      PRINT *,'        sowaflup, sohefldo, soshfldo, sst, sozotaux, sometauy '
      PRINT *,'    coordinates.diags ( clipper like) is required in current dir '
-     STOP
+     STOP 99
   ENDIF
   !!
   CALL getarg (1, cdum)
@@ -418,7 +418,7 @@ PROGRAM cdfflxconv
         READ(numsstp,REC=ntp-1) (( v2d(ji,jj,itt),ji=1,npiglo),jj=1,npjglo)
         itime(itt)=julday(INT(timetagp(ntp-2)) )
      ELSE
-        PRINT *,' Something is wrong in previous file SST ' ; STOP
+        PRINT *,' Something is wrong in previous file SST ' ; STOP 99
      ENDIF
   ENDIF
   DO jt=1,nt
@@ -462,7 +462,7 @@ PROGRAM cdfflxconv
            READ(numsstn,REC=4) (( v2d(ji,jj,itt),ji=1,npiglo),jj=1,npjglo)
            itime(itt)=julday(INT(timetagn(3)) )
         ELSE
-           PRINT *,' Something is wrong in next file SST ' ; STOP
+           PRINT *,' Something is wrong in next file SST ' ; STOP 99
         ENDIF
      ENDIF
   ENDIF

--- a/src/cdfstatcoord.f90
+++ b/src/cdfstatcoord.f90
@@ -59,14 +59,14 @@ PROGRAM cdfstatcoord
      PRINT *,'      '
      PRINT *,'     OUTPUT : '
      PRINT *,'       Standard output'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_coo)
   CALL getarg (2, cf_msk)
   IF ( narg == 3 ) CALL getarg(3, cv_msk)
   
-  IF ( chkfile(cf_coo) .OR. chkfile(cf_msk) ) STOP ! missing files
+  IF ( chkfile(cf_coo) .OR. chkfile(cf_msk) ) STOP 99 ! missing files
 
   npiglo= getdim (cf_coo, cn_x)
   npjglo= getdim (cf_coo, cn_y)

--- a/src/cdfstats.f90
+++ b/src/cdfstats.f90
@@ -106,7 +106,7 @@ PROGRAM cdfstats
       PRINT *,'               rrat   : Signal to noise ratio '
       PRINT *,'               srat   : Signal ratio (stdev ratio) '
       PRINT *,'      '
-      STOP
+      STOP 99
    ENDIF
 
    ! default values
@@ -135,7 +135,7 @@ PROGRAM cdfstats
          CASE ( 5 ) ; cv_name2 = cldum
          CASE DEFAULT
             PRINT *, ' Too many arguments ...'
-            STOP
+            STOP 99
          END SELECT
       END SELECT
     END DO
@@ -147,7 +147,7 @@ PROGRAM cdfstats
    lchk = chkfile ( cf_ref ) .OR. lchk
    lchk = chkfile ( cf_msk ) .OR. lchk
    lchk = chkfile ( cf_hgr ) .OR. lchk
-   IF (lchk ) STOP ! missing files
+   IF (lchk ) STOP 99 ! missing files
 
    ! log arguments do far
    PRINT *,'IN-file   : ', TRIM(cf_in )

--- a/src/cdfstd.f90
+++ b/src/cdfstd.f90
@@ -108,7 +108,7 @@ PROGRAM cdfstd
      PRINT *,'      '
      PRINT *,'     SEE ALSO :'
      PRINT *,'        cdfmoy, cdfrmsssh, cdfstdevw'
-     STOP
+     STOP 99
   ENDIF
   ! look for -save option and one of the file name 
   ijarg = 1
@@ -129,7 +129,7 @@ PROGRAM cdfstd
      END SELECT
   END DO
 
-  IF ( chkfile(cf_in) ) STOP ! missing file
+  IF ( chkfile(cf_in) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_in, cn_x)
   npjglo = getdim (cf_in, cn_y)
@@ -231,7 +231,7 @@ PROGRAM cdfstd
               CASE DEFAULT
                  cf_in=cldum
               END SELECT
-              IF ( chkfile(cf_in) ) STOP ! missing file
+              IF ( chkfile(cf_in) ) STOP 99 ! missing file
 
               IF ( lcaltmean )  THEN
                  npt = getdim (cf_in, cn_t)

--- a/src/cdfstdevts.f90
+++ b/src/cdfstdevts.f90
@@ -71,7 +71,7 @@ PROGRAM cdfstdevts
      PRINT *,'      '
      PRINT *,'     SEA ALSO :'
      PRINT *,'       cdfstd, cdfrmsssh, cdfstdevw.'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1  ; ireq = 0
@@ -84,7 +84,7 @@ PROGRAM cdfstdevts
         CASE ( 1 ) ; cf_in  = cldum
         CASE ( 2 ) ; cf_in2 = cldum
         CASE DEFAULT
-           PRINT *, ' Too many variables ' ; STOP
+           PRINT *, ' Too many variables ' ; STOP 99
         END SELECT
      END SELECT
   ENDDO
@@ -92,7 +92,7 @@ PROGRAM cdfstdevts
   ! check existence of files
   lchk = lchk .OR. chkfile(cf_in )
   lchk = lchk .OR. chkfile(cf_in2)
-  IF (lchk ) STOP ! missing file
+  IF (lchk ) STOP 99 ! missing file
 
   npiglo = getdim (cf_in, cn_x)
   npjglo = getdim (cf_in, cn_y)

--- a/src/cdfstdevw.f90
+++ b/src/cdfstdevw.f90
@@ -80,7 +80,7 @@ PROGRAM cdfstdevw
      PRINT *,'      '
      PRINT *,'     SEA ALSO :'
      PRINT *,'       cdfstd, cdfrmsssh, cdfstdevts.'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1  ; ireq = 0
@@ -96,7 +96,7 @@ PROGRAM cdfstdevw
         CASE ( 2 ) ; cf_in2 = cldum
         CASE ( 3 ) ; cv_in  = cldum ; cf_out='rms_var.nc'
         CASE DEFAULT
-           PRINT *, ' Too many variables ' ; STOP
+           PRINT *, ' Too many variables ' ; STOP 99
         END SELECT
      END SELECT
   ENDDO
@@ -104,7 +104,7 @@ PROGRAM cdfstdevw
   ! check existence of files
   lchk = lchk .OR. chkfile(cf_in )
   lchk = lchk .OR. chkfile(cf_in2)
-  IF (lchk ) STOP ! missing file
+  IF (lchk ) STOP 99 ! missing file
 
   npiglo = getdim (cf_in, cn_x)
   npjglo = getdim (cf_in, cn_y)

--- a/src/cdfstrconv.f90
+++ b/src/cdfstrconv.f90
@@ -82,7 +82,7 @@ PROGRAM cdfstrconv
      PRINT *,'    Output 6 cdf files : for emp, qnet, qsr, sst, taux, tauy with standard var name :'
      PRINT *,'        sowaflup, sohefldo, soshfldo, sst, sozotaux, sometauy '
      PRINT *,'    coordinates.diags ( clipper like) is required in current dir '
-     STOP
+     STOP 99
   ENDIF
   !!
   CALL getarg (1, cdum)

--- a/src/cdfsum.f90
+++ b/src/cdfsum.f90
@@ -98,7 +98,7 @@ PROGRAM cdfsum
      PRINT *,'       Standard output.'
      PRINT *,'       netcdf file : ',TRIM(cf_out),' with 2 variables : vertical profile of sum'
      PRINT *,'                     and 3D sum.'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_in)
@@ -109,12 +109,12 @@ PROGRAM cdfsum
   lchk = chkfile(cn_fzgr) .OR. lchk
   lchk = chkfile(cn_fmsk) .OR. lchk
   lchk = chkfile(cf_in  ) .OR. lchk
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   IF (narg > 3 ) THEN
      IF ( narg /= 9 ) THEN
         PRINT *, ' ERROR : You must give 6 optional values (imin imax jmin jmax kmin kmax)'
-        STOP
+        STOP 99
      ELSE
         ! input optional iimin iimax ijmin ijmax
         CALL getarg ( 4,cldum) ; READ(cldum,*) iimin
@@ -194,7 +194,7 @@ PROGRAM cdfsum
      cv_dep = cn_gdepw
   CASE DEFAULT
      PRINT *, 'this type of variable is not known :', TRIM(cvartype)
-     STOP
+     STOP 99
   END SELECT
 
   e1(:,:) = getvar  (cn_fhgr, cv_e1, 1, npiglo, npjglo, kimin=iimin, kjmin=ijmin)

--- a/src/cdftempvol-full.f90
+++ b/src/cdftempvol-full.f90
@@ -79,7 +79,7 @@ PROGRAM cdftempvol_full
      PRINT '(255a)','         -bimg : 2D (x=lat/lon, y=temp) output on bimg file for hiso, cumul trp, trp'
      PRINT '(255a)',' Files mesh_hgr.nc, mesh_zgr.nc must be in the current directory'
      PRINT '(255a)',' Output on voltemp.txt'
-     STOP
+     STOP 99
   ENDIF
 
   !! Read arguments

--- a/src/cdftools.f90
+++ b/src/cdftools.f90
@@ -89,7 +89,7 @@ CONTAINS
 
     IF ( .NOT. ALLOCATED (dl_glam) ) THEN 
 
-    IF (chkfile (clcoo) ) STOP ! missing file
+    IF (chkfile (clcoo) ) STOP 99 ! missing file
 
     ipiglo= getdim (clcoo, cn_x)
     ipjglo= getdim (clcoo, cn_y)
@@ -356,7 +356,10 @@ CONTAINS
        ! ... compute the nearest ji point on the line crossing at ji
        DO ji=ii0, ii1
           ipts=ipts+1
-          IF (ipts > kpi+kpj) STOP 'ipts > kpi+kpj !'
+          IF (ipts > kpi+kpj) THEN
+             PRINT *, 'ipts > kpi+kpj !'
+             STOP 96
+          ENDIF
           ij=NINT(zaj*ji + zbj )
           ylpt(ipts) = CMPLX(ji,ij)
        END DO
@@ -379,7 +382,10 @@ CONTAINS
        ! ... compute the nearest ji point on the line crossing at jj
        DO jj=ij0,ij1
           ipts=ipts+1
-          IF (ipts > kpi+kpj) STOP 'ipts > kpi+kpj !'
+          IF (ipts > kpi+kpj) THEN
+             PRINT *, 'ipts > kpi+kpj !'
+             STOP 96
+          ENDIF
           ii=NINT(zai*jj + zbi)
           ylpt(ipts) = CMPLX(ii,jj)
        END DO
@@ -398,12 +404,18 @@ CONTAINS
        IF ( zd > 1 ) THEN
           CALL interm_pt(ylpt, jk, zai, zbi, zaj, zbj, ylpti)
           knn=knn+1
-          IF (knn > kpi+kpj) STOP 'knn>kpi+kpj !'
+          IF (knn > kpi+kpj) THEN
+             PRINT *, 'knn>kpi+kpj !'
+             STOP 96
+          ENDIF
           pxx(knn) = REAL(ylpti)
           pyy(knn) = IMAG(ylpti)
        END IF
        knn=knn+1
-       IF (knn > kpi+kpj) STOP 'knn>kpi+kpj !'
+       IF (knn > kpi+kpj) THEN
+          PRINT *, 'knn>kpi+kpj !'
+          STOP 96
+       ENDIF
        pxx(knn) = REAL(ylpt(jk))
        pyy(knn) = IMAG(ylpt(jk))
     END DO

--- a/src/cdftransig_xy3d.f90
+++ b/src/cdftransig_xy3d.f90
@@ -134,7 +134,7 @@ PROGRAM cdftransig_xy3d
      PRINT *,'     SEE ALSO :'
      PRINT *,'      cdfrhoproj, cdfsigtrp' 
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   ! browse command line according to options
@@ -175,10 +175,10 @@ PROGRAM cdftransig_xy3d
   CASE ( 'none'                 ) 
       ! in this case check that all parameters are set individually
       IF ( iset /= 3  ) THEN 
-         PRINT *, ' You must set depref, nbins, sigmin  individually' ; STOP
+         PRINT *, ' You must set depref, nbins, sigmin  individually' ; STOP 99
       ENDIF
   CASE DEFAULT 
-      PRINT *, ' this depcode :',TRIM(cldepcode),' is not available.' ; STOP
+      PRINT *, ' this depcode :',TRIM(cldepcode),' is not available.' ; STOP 99
   END SELECT
 
   ds1scalmin = MIN ( ds1scalmin, ds1scal )
@@ -193,7 +193,7 @@ PROGRAM cdftransig_xy3d
   ! use first tag to look for file dimension
   CALL getarg (istag, ctag)
   cf_vfil = SetFileName (config, ctag, 'V' )
-  IF ( chkfile(cf_vfil) ) STOP ! missing file
+  IF ( chkfile(cf_vfil) ) STOP 99 ! missing file
 
   npiglo = getdim (cf_vfil, cn_x)
   npjglo = getdim (cf_vfil, cn_y)
@@ -320,7 +320,7 @@ PROGRAM cdftransig_xy3d
         lchk =           chkfile ( cf_tfil) 
         lchk = lchk .OR. chkfile ( cf_ufil) 
         lchk = lchk .OR. chkfile ( cf_vfil) 
-        IF ( lchk ) STOP ! missing file
+        IF ( lchk ) STOP 99 ! missing file
         
         IF (jk== 1 ) THEN
            npt = getdim (cf_tfil, cn_t)  ! assuming all files (U V ) contains same number of time frame

--- a/src/cdftransport.f90
+++ b/src/cdftransport.f90
@@ -251,7 +251,7 @@ PROGRAM cdftransport
       PRINT *,'     SEE ALSO :'
       PRINT *,'       cdfsigtrp'
       PRINT *,'      '
-      STOP
+      STOP 99
    ENDIF
 
    itime  = 1
@@ -315,7 +315,7 @@ PROGRAM cdftransport
          lchk = lchk .OR. chkfile(cf_tfil)
       ENDIF
    ENDIF
-   IF ( lchk ) STOP ! missing files
+   IF ( lchk ) STOP 99 ! missing files
 
    ! adjust the number of output variables according to options
    IF ( nclass > 1 ) THEN
@@ -659,7 +659,10 @@ PROGRAM cdftransport
          ! ... compute the nearest ji point on the line crossing at ji
          DO ji=ii0, ii1
             np=np+1
-            IF (np > jpseg) STOP 'np > jpseg !'
+            IF (np > jpseg) THEN
+               PRINT *, 'np > jpseg !'
+               STOP 99
+            ENDIF
             ij=NINT(aj*ji + bj )
             yypt(np) = CMPLX(ji,ij)
          END DO
@@ -682,7 +685,10 @@ PROGRAM cdftransport
          ! ... compute the nearest ji point on the line crossing at jj
          DO jj=ij0,ij1
             np=np+1
-            IF (np > jpseg) STOP 'np > jpseg !'
+            IF (np > jpseg) THEN
+               PRINT *, 'np > jpseg !'
+               STOP 99
+            ENDIF
             ii=NINT(ai*jj + bi)
             yypt(np) = CMPLX(ii,jj)
          END DO
@@ -702,12 +708,18 @@ PROGRAM cdftransport
          IF ( rd > 1 ) THEN
             CALL interm_pt(yypt, jk, ai, bi, aj, bj, yypti)
             nn=nn+1
-            IF (nn > jpseg) STOP 'nn>jpseg !'
+            IF (nn > jpseg) THEN
+               PRINT *, 'nn>jpseg !'
+               STOP 99
+            ENDIF
             rxx(nn) = REAL(yypti)
             ryy(nn) = IMAG(yypti)
          END IF
          nn=nn+1
-         IF (nn > jpseg) STOP 'nn>jpseg !'
+         IF (nn > jpseg) THEN
+            PRINT *, 'nn>jpseg !'
+            STOP 99
+         ENDIF
          rxx(nn) = REAL(yypt(jk))
          ryy(nn) = IMAG(yypt(jk))
       END DO

--- a/src/cdfuv.f90
+++ b/src/cdfuv.f90
@@ -85,7 +85,7 @@ PROGRAM cdfuv
      PRINT *,'                   ',TRIM(cn_vozocrtx)//'_t : Mean U at T point'
      PRINT *,'                   ',TRIM(cn_vomecrty)//'_t : Mean V at T point'
      PRINT *,'                   ',TRIM(CN_VOUV)//'_prime : Mean U''.V'' at T point'
-     STOP
+     STOP 99
   ENDIF
 
   !! Initialisation from 1st file (all file are assume to have the same geometry)

--- a/src/cdfvFWov.f90
+++ b/src/cdfvFWov.f90
@@ -94,7 +94,7 @@ PROGRAM cdfvFWov
      PRINT *,'       Output file only has time relevant dimension. Other dims are set to 1.'
      PRINT *,'       Degenerated dimensions can be removed with :'
      PRINT *,'           ncwga -a x,y,depthw ',TRIM(cf_out), ' -o out.nc'
-     STOP
+     STOP 99
   ENDIF
 
   !! get arguments
@@ -110,7 +110,7 @@ PROGRAM cdfvFWov
   lchk = lchk .OR. chkfile ( cf_hgr  )
   lchk = lchk .OR. chkfile ( cf_mask )
 
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   !! get dimensions of input file containing data
   npiglo = getdim(cf_vfil, cn_x)
@@ -126,7 +126,7 @@ PROGRAM cdfvFWov
   IF ( npjglo /= 2 ) THEN
      PRINT *,' ERROR : This program works with section files.'
      PRINT *,'       all data should have j dimension equal to 2 '
-     STOP
+     STOP 99
   ENDIF
 
   ALLOCATE ( dnetvFW(npt), dtotvFW(npt), dovFW(npt), dtime(npt) )

--- a/src/cdfvT.f90
+++ b/src/cdfvT.f90
@@ -86,7 +86,7 @@ PROGRAM cdfvT
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'       variables : ',TRIM(cn_vozout),', ',TRIM(cn_vozous),', ',TRIM(cn_vomevt),' and ',TRIM(cn_vomevs)
-     STOP
+     STOP 99
   ENDIF
 
   !! Initialisation from 1st file (all file are assume to have the same geometry)

--- a/src/cdfvertmean.f90
+++ b/src/cdfvertmean.f90
@@ -99,7 +99,7 @@ PROGRAM cdfvertmean
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : varin_vertmean (same units as input variable)'
      PRINT *,'      '
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1 ; ireq=0
@@ -118,7 +118,7 @@ PROGRAM cdfvertmean
         CASE ( 4 ) ; READ(cldum,*) rdep_up
         CASE ( 5 ) ; READ(cldum,*) rdep_down
         CASE DEFAULT
-           PRINT *,' Too many arguments ...' ; STOP
+           PRINT *,' Too many arguments ...' ; STOP 99
         END SELECT
      END SELECT
   ENDDO
@@ -126,13 +126,13 @@ PROGRAM cdfvertmean
   lchk = chkfile (cn_fzgr)
   lchk = chkfile (cn_fmsk) .OR. lchk
   lchk = chkfile (cf_in  ) .OR. lchk
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   CALL SetGlobalAtt (cglobal)
 
   IF (rdep_down < rdep_up ) THEN
      PRINT *,'Give depth limits in increasing order !'
-     STOP
+     STOP 99
   ENDIF
 
   npiglo = getdim (cf_in,cn_x)
@@ -152,7 +152,7 @@ PROGRAM cdfvertmean
 
   ! just chck if var exist in file 
   DO jvar = 1, nvaro
-     IF ( chkvar( cf_in, cv_in(jvar)) ) STOP  ! message is written in cdfio.chkvar
+     IF ( chkvar( cf_in, cv_in(jvar)) ) STOP 99 ! message is written in cdfio.chkvar
   ENDDO
 
   ! Allocate arrays
@@ -192,7 +192,7 @@ PROGRAM cdfvertmean
   CASE( 'U','u');  cv_dep=cn_gdepw ; cv_e3='e3u_ps' ; cv_e31d=cn_ve3t 
   CASE( 'V','v');  cv_dep=cn_gdepw ; cv_e3='e3v_ps' ; cv_e31d=cn_ve3t 
   CASE( 'W','w');  cv_dep=cn_gdept ; cv_e3='e3w_ps' ; cv_e31d=cn_ve3w
-  CASE DEFAULT ; PRINT *,'Point type ', TRIM(ctype),' not known! ' ; STOP
+  CASE DEFAULT ; PRINT *,'Point type ', TRIM(ctype),' not known! ' ; STOP 99
   END SELECT
 
                gdep(:) = getvare3(cn_fzgr, cv_dep,  npk)

--- a/src/cdfvhst.f90
+++ b/src/cdfvhst.f90
@@ -71,7 +71,7 @@ PROGRAM cdfvhst
      PRINT *,'     OUTPUT : '
      PRINT *,'         Netcdf file : ',TRIM(cf_out)
      PRINT *,'         Variables : ', TRIM(cn_somevt),', ',TRIM(cn_somevs),', ',TRIM(cn_sozout),' and  ',TRIM(cn_sozous)
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1
@@ -85,7 +85,7 @@ PROGRAM cdfvhst
      END SELECT
   END DO
 
-  IF ( chkfile(cf_vtfil) ) STOP ! missing file
+  IF ( chkfile(cf_vtfil) ) STOP 99 ! missing file
 
   npiglo= getdim (cf_vtfil,cn_x )
   npjglo= getdim (cf_vtfil,cn_y )

--- a/src/cdfvint.f90
+++ b/src/cdfvint.f90
@@ -106,7 +106,7 @@ PROGRAM cdfvint
       PRINT *,'     SEE ALSO :'
       PRINT *,'        cdfvertmean, cdfheatc, cdfmxlhcsc and  cdfmxlheatc'
       PRINT *,'      '
-      STOP
+      STOP 99
    ENDIF
 
    ! default values
@@ -129,7 +129,7 @@ PROGRAM cdfvint
          SELECT CASE ( ij)
          CASE ( 1 ) ; cf_in = cldum
          CASE ( 2 ) ; cv_in = cldum
-         CASE DEFAULT ; PRINT *, ' ERROR: Too many arguments ! ' ; STOP
+         CASE DEFAULT ; PRINT *, ' ERROR: Too many arguments ! ' ; STOP 99
          END SELECT
       END SELECT
    END DO
@@ -139,7 +139,7 @@ PROGRAM cdfvint
    lchk = chkfile ( cn_fmsk ) .OR. lchk
    lchk = chkfile ( cn_fhgr ) .OR. lchk
    lchk = chkfile ( cn_fzgr ) .OR. lchk
-   IF ( lchk ) STOP ! missing files
+   IF ( lchk ) STOP 99 ! missing files
   
    IF ( ltmean .AND. cv_in == cn_vosaline ) THEN
        PRINT *,' WARNING : flag -tmean is useless with variable', TRIM(cv_in)
@@ -178,7 +178,7 @@ PROGRAM cdfvint
    ELSE
       PRINT *,'  ERROR: Variable ', TRIM(cv_in), ' not pre-defined ...'
       PRINT *,'     Accepted variables are ', TRIM(cn_votemper),' and ',TRIM(cn_vosaline)
-      STOP
+      STOP 99
    ENDIF
 
    ! log information so far

--- a/src/cdfvita-geo.f90
+++ b/src/cdfvita-geo.f90
@@ -80,7 +80,7 @@ PROGRAM cdfvita_geo
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : sovitua, sovitva, sovitmod, [sovitwa]'
-     STOP
+     STOP 99
   ENDIF
 
   nlev = 0
@@ -110,10 +110,10 @@ PROGRAM cdfvita_geo
 
   ALLOCATE ( ipk(nvar), id_varout(nvar), stypvar(nvar) )
 
-  IF ( chkfile(cf_ufil) .OR. chkfile(cf_vfil) .OR. chkfile(cf_tfil) ) STOP ! missing file
+  IF ( chkfile(cf_ufil) .OR. chkfile(cf_vfil) .OR. chkfile(cf_tfil) ) STOP 99 ! missing file
 
   IF ( lvertical ) THEN 
-     IF ( chkfile(cf_wfil) ) STOP ! missing file
+     IF ( chkfile(cf_wfil) ) STOP 99 ! missing file
   ENDIF
 
   npiglo = getdim (cf_ufil,cn_x)

--- a/src/cdfvita.f90
+++ b/src/cdfvita.f90
@@ -97,7 +97,7 @@ PROGRAM cdfvita
       PRINT *,'     OUTPUT : '
       PRINT *,'       netcdf file : ', TRIM(cf_out) ,' unless -o option is used'
       PRINT *,'         variables : sovitua, sovitva, sovitmod, sovitdir, [sovitmod3], [sovitwa]'
-      STOP
+      STOP 99
    ENDIF
 
    nlev = 0
@@ -138,10 +138,10 @@ PROGRAM cdfvita
 
    ALLOCATE ( ipk(nvar), id_varout(nvar), stypvar(nvar) )
 
-   IF ( chkfile(cf_ufil) .OR. chkfile(cf_vfil) .OR. chkfile(cf_tfil) ) STOP ! missing file
+   IF ( chkfile(cf_ufil) .OR. chkfile(cf_vfil) .OR. chkfile(cf_tfil) ) STOP 99 ! missing file
 
    IF ( lvertical ) THEN 
-      IF ( chkfile(cf_wfil) ) STOP ! missing file
+      IF ( chkfile(cf_wfil) ) STOP 99 ! missing file
    ENDIF
 
    npiglo = getdim (cf_ufil,cn_x)

--- a/src/cdfvsig.f90
+++ b/src/cdfvsig.f90
@@ -132,7 +132,7 @@ PROGRAM cdfvsig
      PRINT *,'                                            at velocity point.'
      PRINT *,'                   vosigu, vosigv, vosigw : mean sigma-0 at velocity point.'
      PRINT *,'                   ',TRIM(cn_vozocrtx),', ',TRIM(cn_vomecrty),', ',TRIM(cn_vovecrtz),' : mean velocity components.'
-     STOP
+     STOP 99
   ENDIF
 
   !! Initialisation from 1st file (all file are assume to have the same geometry)

--- a/src/cdfvtrp.f90
+++ b/src/cdfvtrp.f90
@@ -88,7 +88,7 @@ PROGRAM cdfvtrp
      PRINT *,'          If option -bathy is used :'
      PRINT *,'           ', TRIM(cv_soastrp),' : along slope transport'
      PRINT *,'           ', TRIM(cv_socstrp),' : cross slope transport'
-     STOP
+     STOP 99
   ENDIF
 
   ! scan command line and set flags
@@ -113,7 +113,7 @@ PROGRAM cdfvtrp
   lchk = lchk .OR. chkfile ( cf_ufil )
   lchk = lchk .OR. chkfile ( cf_vfil )
   IF ( lbathy ) lchk = lchk .OR. chkfile ( cn_fmsk )
-  IF ( lchk ) STOP   ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   ALLOCATE ( ipk(nvarout), id_varout(nvarout), stypvar(nvarout) )
 

--- a/src/cdfw.f90
+++ b/src/cdfw.f90
@@ -81,7 +81,7 @@ PROGRAM cdfw
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'         variables : ', TRIM(cn_vovecrtz),' (m/s)'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1
@@ -104,7 +104,7 @@ PROGRAM cdfw
   lchk = chkfile (cn_fzgr) .OR. lchk
   lchk = chkfile (cf_ufil) .OR. lchk
   lchk = chkfile (cf_vfil) .OR. lchk
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   npiglo = getdim(cf_ufil,cn_x)
   npjglo = getdim(cf_ufil,cn_y)

--- a/src/cdfweight.f90
+++ b/src/cdfweight.f90
@@ -106,7 +106,7 @@ PROGRAM cdfweight
      PRINT *,'       binary weight file : weight_point_type.bin'
      PRINT *,'       standard output : almost the same info that is saved in the binary file'
      PRINT *,'                   When using -v option, even more informations !'
-     STOP
+     STOP 99
   ENDIF
 
   iarg=1
@@ -125,7 +125,7 @@ PROGRAM cdfweight
   llchk = llchk .OR. chkfile(cf_in)
   llchk = llchk .OR. chkfile(cf_coord)
   IF ( .NOT. ll2d ) llchk = llchk .OR. chkfile(cn_fzgr)
-  IF ( llchk ) STOP ! missing files
+  IF ( llchk ) STOP 99 ! missing files
 
   npiglo = getdim (cf_coord,cn_x)
   npjglo = getdim (cf_coord,cn_y)

--- a/src/cdfwflx.f90
+++ b/src/cdfwflx.f90
@@ -72,7 +72,7 @@ PROGRAM cdfwflx
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
      PRINT *,'       variables : soevap, soprecip, sorunoff, sowadmp, sowaflux'
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_tfil)
@@ -80,7 +80,7 @@ PROGRAM cdfwflx
 
   lchk = lchk .OR. chkfile ( cf_tfil)
   lchk = lchk .OR. chkfile ( cf_rnf )
-  IF ( lchk ) STOP ! missing file
+  IF ( lchk ) STOP 99 ! missing file
 
   npiglo= getdim (cf_tfil, cn_x)
   npjglo= getdim (cf_tfil, cn_y)

--- a/src/cdfwhereij.f90
+++ b/src/cdfwhereij.f90
@@ -61,7 +61,7 @@ PROGRAM cdfwhereij
      PRINT *,'      '
      PRINT *,'     OUTPUT : '
      PRINT *,'       Standard output'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1 ; ireq = 0
@@ -78,24 +78,24 @@ PROGRAM cdfwhereij
         CASE ( 3 ) ; READ(cldum,*) ijmin
         CASE ( 4 ) ; READ(cldum,*) ijmax
         CASE DEFAULT
-           PRINT *,' Too many arguments !' ; STOP
+           PRINT *,' Too many arguments !' ; STOP 99
         END SELECT
      END SELECT
   END DO
 
-  IF ( chkfile(clcoo) ) STOP ! missing file
+  IF ( chkfile(clcoo) ) STOP 99 ! missing file
 
   npiglo = getdim (clcoo, cn_x)
   npjglo = getdim (clcoo, cn_y)
 
   IF ( iimax > npiglo ) THEN
      PRINT *,' ERROR : imax is greater than the maximum size ', iimax, npiglo
-     STOP
+     STOP 99
   ENDIF
 
   IF ( ijmax > npjglo ) THEN
      PRINT *,' ERROR : jmax is greater than the maximum size ', ijmax, npjglo
-     STOP
+     STOP 99
   END IF
 
   ALLOCATE (glam(npiglo,npjglo), gphi(npiglo,npjglo) )

--- a/src/cdfzisot.f90
+++ b/src/cdfzisot.f90
@@ -69,12 +69,12 @@ PROGRAM cdfzisot
      PRINT *,'      '
      PRINT *,'     OUTPUT : '
      PRINT *,'       netcdf file : ', TRIM(cf_out) 
-     STOP
+     STOP 99
   ENDIF
 
   ! get input gridT filename
   CALL getarg (1, cf_tfil)
-  IF ( chkfile(cf_tfil) .OR. chkfile(cn_fzgr) ) STOP ! missing file
+  IF ( chkfile(cf_tfil) .OR. chkfile(cn_fzgr) ) STOP 99 ! missing file
 
   ! get reference temperature
   CALL getarg (2, cdum)
@@ -87,7 +87,7 @@ PROGRAM cdfzisot
   ENDIF
   IF ( rtref > 50 .OR. rtref < -3. ) THEN
      PRINT*,'Sea Water temperature on Earth, not Pluton ! ',rtref
-     STOP
+     STOP 99
   ENDIF
 
   ! get (optional) output file name

--- a/src/cdfzonalmean.f90
+++ b/src/cdfzonalmean.f90
@@ -129,7 +129,7 @@ PROGRAM cdfzonalmean
      PRINT *,'                      if a BASIN-file is used.'
      PRINT *,'                 If option -max is used, each standard output variable'
      PRINT *,'                     is associated with a var_max variable.'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1  ; ireq = 0
@@ -152,7 +152,7 @@ PROGRAM cdfzonalmean
                  npbasins   = 5
                  lchk       = chkfile (cf_basins)
       CASE DEFAULT 
-        PRINT *,' Too many arguments ...' ; STOP
+        PRINT *,' Too many arguments ...' ; STOP 99
       END SELECT
     END SELECT
   END DO
@@ -171,7 +171,7 @@ PROGRAM cdfzonalmean
   lchk = lchk .OR. chkfile (cn_fzgr)
   lchk = lchk .OR. chkfile (cn_fmsk)
   lchk = lchk .OR. chkfile (cf_in  )
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   ! set the metrics according to C grid point
   SELECT CASE (ctyp)
@@ -196,7 +196,7 @@ PROGRAM cdfzonalmean
      cv_depi = cn_gdepw   ; cv_depo = cn_vdepthw
      cv_phi  = cn_gphit   ; cv_msk  = 'tmask'
   CASE DEFAULT
-     PRINT *, ' C grid:', TRIM(ctyp),' point not known!' ; STOP
+     PRINT *, ' C grid:', TRIM(ctyp),' point not known!' ; STOP 99
   END SELECT
 
   nvarin  = getnvar(cf_in)   ! number of input variables in file

--- a/src/cdfzonalmeanvT.f90
+++ b/src/cdfzonalmeanvT.f90
@@ -110,7 +110,7 @@ PROGRAM cdfzonalmeanvT
       PRINT *,'                       A suffix _bas is append to variable name oin order to'
       PRINT *,'                     indicate the basin (atl, inp, ind, pac) or glo for global'
       PRINT *,'         '
-      STOP
+      STOP 99
    ENDIF
 
    ! decode command line
@@ -148,10 +148,10 @@ PROGRAM cdfzonalmeanvT
    IF ( npbasins /=1 ) THEN
       lchk = lchk .OR. chkfile (cf_basins  )
    ENDIF
-   IF ( lchk ) STOP ! missing files
+   IF ( lchk ) STOP 99 ! missing files
 
    cf_tfil = SetFileName( confcase, cldum, 'T')  ! look in first T file for dimensions
-   IF ( chkfile (cf_tfil) ) STOP 
+   IF ( chkfile (cf_tfil) ) STOP 99
 
    npiglo = getdim (cf_tfil,cn_x)
    npjglo = getdim (cf_tfil,cn_y)

--- a/src/cdfzonalout.f90
+++ b/src/cdfzonalout.f90
@@ -60,11 +60,11 @@ PROGRAM cdfzonalout
      PRINT *,'     OUTPUT : '
      PRINT *,'        - Standard output,  structured in columns:'
      PRINT *,'             J  LAT  ( zonal mean, var = 1--> nvar) '
-     STOP
+     STOP 99
   ENDIF
 
   CALL getarg (1, cf_zonal)
-  IF ( chkfile(cf_zonal) ) STOP ! missing file
+  IF ( chkfile(cf_zonal) ) STOP 99 ! missing file
 
   nvarin  = getnvar(cf_zonal)
   ALLOCATE ( cv_names(nvarin), ipki(nvarin), id_varin(nvarin), stypvar(nvarin)  )

--- a/src/cdfzonalsum.f90
+++ b/src/cdfzonalsum.f90
@@ -129,7 +129,7 @@ PROGRAM cdfzonalsum
      PRINT *,'                      if a BASIN-file is used.'
      PRINT *,'            Units are modified by adding ''.m2'' at the end. Can be improved !'
      PRINT *,'            In addition, ''.degree-1'' is append to unit with -pdeg option.'
-     STOP
+     STOP 99
   ENDIF
 
   ijarg = 1  ; ireq = 0
@@ -151,7 +151,7 @@ PROGRAM cdfzonalsum
                  npbasins   = 5
                  lchk       = chkfile (cf_basins)
       CASE DEFAULT 
-        PRINT *,' Too many arguments ...' ; STOP
+        PRINT *,' Too many arguments ...' ; STOP 99
       END SELECT
     END SELECT
   END DO
@@ -169,7 +169,7 @@ PROGRAM cdfzonalsum
   lchk = lchk .OR. chkfile (cn_fzgr)
   lchk = lchk .OR. chkfile (cn_fmsk)
   lchk = lchk .OR. chkfile (cf_in  )
-  IF ( lchk ) STOP ! missing files
+  IF ( lchk ) STOP 99 ! missing files
 
   ! set the metrics according to C grid point
   SELECT CASE (ctyp)
@@ -194,7 +194,7 @@ PROGRAM cdfzonalsum
      cv_depi = cn_gdepw   ; cv_depo = cn_vdepthw
      cv_phi  = cn_gphit   ; cv_msk  = 'tmask'
   CASE DEFAULT
-     PRINT *, ' C grid:', TRIM(ctyp),' point not known!' ; STOP
+     PRINT *, ' C grid:', TRIM(ctyp),' point not known!' ; STOP 99
   END SELECT
 
   nvarin  = getnvar(cf_in)   ! number of input variables

--- a/src/cdfzoom.f90
+++ b/src/cdfzoom.f90
@@ -69,7 +69,7 @@ PROGRAM cdfzoom
      PRINT *,'      '
      PRINT *,'     OUTPUT : '
      PRINT *,'       display on standard output'
-     STOP
+     STOP 99
   ENDIF
   !
   ikext = 1 ; ikmin = 1 ; ikmax = 1 ; itmin = 1 ; itmax = 1
@@ -99,11 +99,11 @@ PROGRAM cdfzoom
         CALL getarg(ijarg,cv_in) ; ijarg = ijarg + 1
      CASE DEFAULT
         PRINT *, TRIM(cldum),' : unknown option '
-        STOP
+        STOP 99
      END SELECT
   END DO
 
-  IF ( chkfile (cf_in) ) STOP ! missing file
+  IF ( chkfile (cf_in) ) STOP 99 ! missing file
   !
   ni=0 ; nj=0 ; nk=0 ; nt=0 
   niz  = iimax - iimin + 1
@@ -117,7 +117,7 @@ PROGRAM cdfzoom
      ELSE IF ( njz == 1 ) THEN ! x/z slab
      ELSE
         PRINT *, 'Either niz or njz must me  one'
-        STOP
+        STOP 99
      ENDIF
   ENDIF
 
@@ -125,7 +125,7 @@ PROGRAM cdfzoom
   IF ( ierr == 1 ) THEN 
      ni = getdim(cf_in, 'lon', cldum, ierr)
      IF ( ierr == 1 ) THEN
-        PRINT *,' No X or lon dim found ' ; STOP
+        PRINT *,' No X or lon dim found ' ; STOP 99
      ENDIF
   ENDIF
 
@@ -133,7 +133,7 @@ PROGRAM cdfzoom
   IF ( ierr == 1 ) THEN 
      nj = getdim(cf_in, 'lat', cldum, ierr)
      IF ( ierr == 1 ) THEN
-        PRINT *,' No y or lat dim found ' ; STOP
+        PRINT *,' No y or lat dim found ' ; STOP 99
      ENDIF
   ENDIF
 
@@ -158,7 +158,7 @@ PROGRAM cdfzoom
 
   IF ( itmax > nt ) THEN 
      PRINT *,' Not enough time steps in this file' 
-     STOP
+     STOP 99
   ENDIF
 
   IF (nk == 0 ) THEN ; nk = 1 ; ikext = 1 ; ENDIF  ! assume a 2D variable

--- a/src/modutils.f90
+++ b/src/modutils.f90
@@ -95,7 +95,7 @@ CONTAINS
        WRITE(SetFileName,'(a,"_",a,"_grid_",a,".nc")') TRIM(cdconf), TRIM(cdtag), TRIM(cdgrid)
        IF ( chkfile( SetFileName, ld_verbose=.FALSE.) .AND. ll_stop  ) THEN
           PRINT *,' ERROR : missing grid',TRIM(cdgrid),'or even grid_',TRIM(cdgrid),' file '
-          STOP
+          STOP 97
        ENDIF
     ENDIF
   END FUNCTION SetFileName
@@ -134,13 +134,21 @@ CONTAINS
 
        iposm=INDEX(cldum2,'-')
        IF ( iposm == 0 ) THEN
-          ksiz=ksiz+1 ; IF (ksiz > jp_maxlist) STOP 'jp_maxlist too small in getlist '
+          ksiz=ksiz+1 ; 
+          IF (ksiz > jp_maxlist) THEN 
+             PRINT *, 'jp_maxlist too small in getlist '
+             STOP 97
+          ENDIF
           READ(cldum2,* ) itmp(ksiz)
        ELSE
           READ(cldum2(1:iposm-1),*) ik1
           READ(cldum2(iposm+1:),* ) ik2
           DO jk = ik1,ik2
-             ksiz=ksiz+1 ; IF (ksiz > jp_maxlist) STOP 'jp_maxlist too small in getlist '
+             ksiz=ksiz+1 ; 
+             IF (ksiz > jp_maxlist) THEN
+                PRINT *, 'jp_maxlist too small in getlist '
+                STOP 97
+             ENDIF
              itmp(ksiz)=jk
           ENDDO
        ENDIF
@@ -205,7 +213,7 @@ CONTAINS
     ! check cdfs compliance
     IF ( cdfs(1:4)  .NE. 'fill' .AND. cdfs(1:6) .NE. 'smooth' ) THEN
        PRINT*, 'cdfs = ',cdfs ,' <> fill or smooth'
-       STOP
+       STOP 97
     ENDIF
     !
     ! ... Shapiro filter : 


### PR DESCRIPTION
I replaced all the STOP statement in CDFTOOLS by STOP XX to have a correct exit code ($? in shell) in case of error. 
99 general cdftool as cdfmoy
98 cdfio
97 modutil
96 cdftools

No other changes. 

Process for the change:
cdfio + modutil + cdftool.f90 by hand

all the rest: 
for file in *90; do echo $file ; sed -r -i "s/STOP +!/STOP 99 !/g" $file; done
for file in *90; do echo $file ; sed -r -i "s/(STOP$|STOP [^A-Za-z0-9!'])/STOP 99/g" $file ; done